### PR TITLE
[FEAT] 트리 테스트 질문 생성 UI 구현

### DIFF
--- a/src/features/test-create/model/types.ts
+++ b/src/features/test-create/model/types.ts
@@ -82,8 +82,11 @@ export const QUESTION_TYPES = [
 export type QuestionTypeId = (typeof QUESTION_TYPES)[number]["id"];
 
 import type { MultipleQuestionData } from "@/features/test-multiple/model/types";
+import type { TreeQuestionData } from "@/features/test-tree/model/types";
 
-export type QuestionData = { typeId: "multiple" } & MultipleQuestionData;
+export type QuestionData =
+  | ({ typeId: "multiple" } & MultipleQuestionData)
+  | ({ typeId: "tree" } & TreeQuestionData);
 // 추후: | { typeId: "subjective" } & SubjectiveQuestionData
 
 export interface PendingQuestion {

--- a/src/features/test-create/ui/TestCreateFunnel.tsx
+++ b/src/features/test-create/ui/TestCreateFunnel.tsx
@@ -19,6 +19,7 @@ import { useTestCreateForm } from "../model/useTestCreateForm";
 import type { EditPhase, QuestionTypeId } from "../model/types";
 import { ROUTES } from "@/shared/constants/routes";
 import { MultipleCreatePage } from "@/features/test-multiple/ui";
+import { TreeCreatePage } from "@/features/test-tree/ui";
 
 export function TestCreateFunnel() {
   const navigate = useNavigate();
@@ -253,7 +254,9 @@ export function TestCreateFunnel() {
         {activeQuestion?.typeId === "scale" && <></>}
         {activeQuestion?.typeId === "ab" && <></>}
         {activeQuestion?.typeId === "card" && <></>}
-        {activeQuestion?.typeId === "tree" && <></>}
+        {activeQuestion?.typeId === "tree" && (
+          <TreeCreatePage key="question-tree" questionId={activeQuestion.id} onClose={() => setActiveQuestion(null)} />
+        )}
         {activeQuestion?.typeId === "fivesec" && <></>}
       </AnimatePresence>
 

--- a/src/features/test-tree/model/types.ts
+++ b/src/features/test-tree/model/types.ts
@@ -1,0 +1,11 @@
+export interface TreeNodeItem {
+  id: string;
+  name: string;
+  children: TreeNodeItem[];
+}
+
+export interface TreeQuestionData {
+  title: string;
+  description: string;
+  nodes: TreeNodeItem[];
+}

--- a/src/features/test-tree/ui/TreeCreateBottomCTA.tsx
+++ b/src/features/test-tree/ui/TreeCreateBottomCTA.tsx
@@ -1,0 +1,28 @@
+import { CTAButton, FixedBottomCTA } from "@toss/tds-mobile";
+
+interface TreeCreateBottomCTAProps {
+  isCompleteDisabled: boolean;
+  onCancel: () => void;
+  onComplete: () => void;
+}
+
+export function TreeCreateBottomCTA({
+  isCompleteDisabled,
+  onCancel,
+  onComplete,
+}: TreeCreateBottomCTAProps) {
+  return (
+    <FixedBottomCTA.Double
+      leftButton={
+        <CTAButton color="dark" variant="weak" onClick={onCancel}>
+          취소
+        </CTAButton>
+      }
+      rightButton={
+        <CTAButton disabled={isCompleteDisabled} onClick={onComplete}>
+          완료하기
+        </CTAButton>
+      }
+    />
+  );
+}

--- a/src/features/test-tree/ui/TreeCreateOptionSection.tsx
+++ b/src/features/test-tree/ui/TreeCreateOptionSection.tsx
@@ -165,10 +165,11 @@ export function TreeCreateOptionSection({
                 aria-selected={isSelected}
                 aria-label={node.name}
                 onClick={() => onSelectNode(node.id)}
-                className="rounded-full px-3.5 py-1.5 text-[14px] font-semibold transition-colors"
+                className="px-3.5 py-1.5 text-[14px] font-semibold transition-colors"
                 style={{
                   backgroundColor: isSelected ? adaptive.grey900 : adaptive.greyOpacity100,
                   color: isSelected ? adaptive.grey50 : adaptive.grey700,
+                  borderRadius: "9999px",
                 }}
               >
                 {node.name}

--- a/src/features/test-tree/ui/TreeCreateOptionSection.tsx
+++ b/src/features/test-tree/ui/TreeCreateOptionSection.tsx
@@ -72,21 +72,15 @@ function TreeNodeRow({ node, depth, isManageMode, onEditNode, onAddChildNode, on
                 aria-label={`${node.name} 이름 수정`}
                 onClick={() => onEditNode(node.id)}
               />
-              <button
-                type="button"
+              <IconButton
+                src="https://static.toss.im/icons/png/4x/icon-plus-thin-mono.png"
+                variant="clear"
+                iconSize={16}
+                color={isAddDisabled ? adaptive.grey300 : adaptive.grey600}
+                disabled={isAddDisabled}
                 aria-label={`${node.name} 하위 항목 추가`}
                 onClick={() => onAddChildNode(node.id)}
-                disabled={isAddDisabled}
-                className="flex items-center justify-center disabled:cursor-not-allowed"
-              >
-                <Asset.Icon
-                  frameShape={Asset.frameShape.CleanW20}
-                  backgroundColor="transparent"
-                  name="icon-plus-thin-mono"
-                  color={isAddDisabled ? adaptive.grey300 : adaptive.grey600}
-                  aria-hidden
-                />
-              </button>
+              />
             </>
           )}
         </div>
@@ -171,11 +165,10 @@ export function TreeCreateOptionSection({
                 aria-selected={isSelected}
                 aria-label={node.name}
                 onClick={() => onSelectNode(node.id)}
-                className="px-3.5 py-1.5 text-[14px] font-semibold transition-colors"
+                className="rounded-full px-3.5 py-1.5 text-[14px] font-semibold transition-colors"
                 style={{
                   backgroundColor: isSelected ? adaptive.grey900 : adaptive.greyOpacity100,
                   color: isSelected ? adaptive.grey50 : adaptive.grey700,
-                  borderRadius: "9999px",
                 }}
               >
                 {node.name}

--- a/src/features/test-tree/ui/TreeCreateOptionSection.tsx
+++ b/src/features/test-tree/ui/TreeCreateOptionSection.tsx
@@ -133,8 +133,8 @@ export function TreeCreateOptionSection({
                 typography="t5"
                 fontWeight="medium"
                 size="small"
-                disabled={!hasNodes}
-                onClick={hasNodes ? onToggleManageMode : undefined}
+                disabled={!isManageMode && !hasNodes}
+                onClick={isManageMode || hasNodes ? onToggleManageMode : undefined}
               >
                 {isManageMode ? "저장하기" : "수정하기"}
               </TextButton>

--- a/src/features/test-tree/ui/TreeCreateOptionSection.tsx
+++ b/src/features/test-tree/ui/TreeCreateOptionSection.tsx
@@ -1,0 +1,202 @@
+import { Asset, IconButton, ListHeader, ListRow, Text, TextButton } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+import type { TreeNodeItem } from "../model/types";
+
+const ListHeaderTitleParagraph = ListHeader.TitleParagraph;
+
+const MAX_TREE_DEPTH = 4;
+
+interface TreeCreateOptionSectionProps {
+  nodes: TreeNodeItem[];
+  selectedNodeId: string | null;
+  isManageMode: boolean;
+  onOpenNodeEditor: () => void;
+  onSelectNode: (nodeId: string) => void;
+  onEditNode: (nodeId: string) => void;
+  onAddChildNode: (nodeId: string) => void;
+  onToggleManageMode: () => void;
+  onDeleteNode: (nodeId: string) => void;
+}
+
+interface TreeNodeRowProps {
+  node: TreeNodeItem;
+  depth: number;
+  isManageMode?: boolean;
+  onEditNode: (nodeId: string) => void;
+  onAddChildNode: (nodeId: string) => void;
+  onDeleteNode?: (nodeId: string) => void;
+}
+
+function TreeNodeRow({ node, depth, isManageMode, onEditNode, onAddChildNode, onDeleteNode }: TreeNodeRowProps) {
+  const hasChildren = node.children.length > 0;
+  const isAddDisabled = depth >= MAX_TREE_DEPTH - 1;
+  return (
+    <>
+      <div
+        className="flex items-center justify-between py-2 pr-5"
+        style={{ paddingLeft: `${20 + depth * 16}px` }}
+      >
+        <div className="flex items-center gap-1.5">
+          {hasChildren ? (
+            <Asset.Icon
+              frameShape={Asset.frameShape.CleanW16}
+              backgroundColor="transparent"
+              name="icon-arrow-solid-down-mono"
+              color={adaptive.grey500}
+              aria-hidden
+            />
+          ) : (
+            <div style={{ width: 16 }} />
+          )}
+          <Text display="block" color={adaptive.grey700} typography="t5" fontWeight="regular">
+            {node.name}
+          </Text>
+        </div>
+        <div className="flex items-center gap-1">
+          {isManageMode ? (
+            <IconButton
+              src="https://static.toss.im/icons/png/4x/icon-simplebin-line-mono.png"
+              variant="clear"
+              iconSize={16}
+              color={adaptive.grey600}
+              aria-label={`${node.name} 삭제`}
+              onClick={() => onDeleteNode?.(node.id)}
+            />
+          ) : (
+            <>
+              <IconButton
+                src="https://static.toss.im/icons/png/4x/icon-pencil-18px-mono.png"
+                variant="clear"
+                iconSize={16}
+                color={adaptive.grey600}
+                aria-label={`${node.name} 이름 수정`}
+                onClick={() => onEditNode(node.id)}
+              />
+              <button
+                type="button"
+                aria-label={`${node.name} 하위 항목 추가`}
+                onClick={() => onAddChildNode(node.id)}
+                disabled={isAddDisabled}
+                className="flex items-center justify-center disabled:cursor-not-allowed"
+              >
+                <Asset.Icon
+                  frameShape={Asset.frameShape.CleanW20}
+                  backgroundColor="transparent"
+                  name="icon-plus-thin-mono"
+                  color={isAddDisabled ? adaptive.grey300 : adaptive.grey600}
+                  aria-hidden
+                />
+              </button>
+            </>
+          )}
+        </div>
+      </div>
+      {node.children.map((child) => (
+        <TreeNodeRow
+          key={child.id}
+          node={child}
+          depth={depth + 1}
+          isManageMode={isManageMode}
+          onEditNode={onEditNode}
+          onAddChildNode={onAddChildNode}
+          onDeleteNode={onDeleteNode}
+        />
+      ))}
+    </>
+  );
+}
+
+export function TreeCreateOptionSection({
+  nodes,
+  selectedNodeId,
+  isManageMode,
+  onOpenNodeEditor,
+  onSelectNode,
+  onEditNode,
+  onAddChildNode,
+  onToggleManageMode,
+  onDeleteNode,
+}: TreeCreateOptionSectionProps) {
+  const hasNodes = nodes.length > 0;
+  const selectedNode = nodes.find((node) => node.id === selectedNodeId) ?? nodes[0] ?? null;
+
+  return (
+    <>
+      <div className="pr-5">
+        <ListHeader
+          descriptionPosition="bottom"
+          rightAlignment="center"
+          titleWidthRatio={0.6}
+          title={
+            <ListHeaderTitleParagraph typography="t5" fontWeight="medium" color={adaptive.grey600}>
+              트리 목록
+            </ListHeaderTitleParagraph>
+          }
+          right={
+            <div className="pr-1">
+              <TextButton
+                color={adaptive.blue500}
+                typography="t5"
+                fontWeight="medium"
+                size="small"
+                disabled={!hasNodes}
+                onClick={hasNodes ? onToggleManageMode : undefined}
+              >
+                {isManageMode ? "저장하기" : "수정하기"}
+              </TextButton>
+            </div>
+          }
+          className="w-full"
+        />
+      </div>
+
+      {!isManageMode ? (
+        <ListRow
+          left={<ListRow.AssetIcon shape="original" name="icon-plus-grey-fill" color={adaptive.grey400} variant="fill" />}
+          contents={<ListRow.Texts type="1RowTypeA" top="추가하기" topProps={{ color: adaptive.grey700 }} />}
+          verticalPadding="large"
+          onClick={onOpenNodeEditor}
+        />
+      ) : null}
+
+      {hasNodes ? (
+        <div role="tablist" className="flex flex-wrap gap-2 px-5 pt-2">
+          {nodes.map((node) => {
+            const isSelected = selectedNode?.id === node.id;
+            return (
+              <button
+                key={node.id}
+                type="button"
+                role="tab"
+                aria-selected={isSelected}
+                aria-label={node.name}
+                onClick={() => onSelectNode(node.id)}
+                className="px-3.5 py-1.5 text-[14px] font-semibold transition-colors"
+                style={{
+                  backgroundColor: isSelected ? adaptive.grey900 : adaptive.greyOpacity100,
+                  color: isSelected ? adaptive.grey50 : adaptive.grey700,
+                  borderRadius: "9999px",
+                }}
+              >
+                {node.name}
+              </button>
+            );
+          })}
+        </div>
+      ) : null}
+
+      {selectedNode ? (
+        <div className="pt-3">
+          <TreeNodeRow
+            node={selectedNode}
+            depth={0}
+            isManageMode={isManageMode}
+            onEditNode={onEditNode}
+            onAddChildNode={onAddChildNode}
+            onDeleteNode={onDeleteNode}
+          />
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/src/features/test-tree/ui/TreeCreatePage.tsx
+++ b/src/features/test-tree/ui/TreeCreatePage.tsx
@@ -1,0 +1,187 @@
+import { useState } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import type { TreeNodeItem } from "../model/types";
+import { TreeCreateBottomCTA } from "./TreeCreateBottomCTA";
+import { TreeCreateOptionSection } from "./TreeCreateOptionSection";
+import { TreeCreateTopSection } from "./TreeCreateTopSection";
+import { TreeNodeAddSheet } from "./TreeNodeAddSheet";
+import { TreeQuestionEditorOverlay } from "./TreeQuestionEditorOverlay";
+import { useTestCreateForm } from "@/features/test-create/model/useTestCreateForm";
+
+
+interface TreeCreatePageProps {
+  questionId: string;
+  onClose: () => void;
+}
+
+type NodeSheetMode =
+  | { kind: "create-root" }
+  | { kind: "rename"; nodeId: string; initialName: string };
+
+export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
+  const { updateQuestion, questions } = useTestCreateForm();
+  const existing = questions.find((q) => q.id === questionId)?.data;
+
+  const [questionTitle, setQuestionTitle] = useState(
+    existing?.typeId === "tree" ? existing.title : "",
+  );
+  const [questionDescription, setQuestionDescription] = useState(
+    existing?.typeId === "tree" ? existing.description : "",
+  );
+  const [nodes, setNodes] = useState<TreeNodeItem[]>(
+    existing?.typeId === "tree" ? existing.nodes : [],
+  );
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [isManageMode, setIsManageMode] = useState(false);
+  const [isQuestionEditorOpen, setIsQuestionEditorOpen] = useState(false);
+  const [nodeSheetMode, setNodeSheetMode] = useState<NodeSheetMode | null>(null);
+
+  const isCompleteDisabled =
+    questionTitle.trim().length === 0 || nodes.length === 0;
+
+  const findNode = (
+    list: TreeNodeItem[],
+    nodeId: string,
+  ): TreeNodeItem | null => {
+    for (const node of list) {
+      if (node.id === nodeId) return node;
+      const found = findNode(node.children, nodeId);
+      if (found) return found;
+    }
+    return null;
+  };
+
+  const renameNode = (
+    list: TreeNodeItem[],
+    nodeId: string,
+    name: string,
+  ): TreeNodeItem[] =>
+    list.map((node) =>
+      node.id === nodeId
+        ? { ...node, name }
+        : { ...node, children: renameNode(node.children, nodeId, name) },
+    );
+
+  const deleteNode = (
+    list: TreeNodeItem[],
+    nodeId: string,
+  ): TreeNodeItem[] =>
+    list
+      .filter((node) => node.id !== nodeId)
+      .map((node) => ({ ...node, children: deleteNode(node.children, nodeId) }));
+
+  const appendChild = (
+    list: TreeNodeItem[],
+    parentId: string,
+    child: TreeNodeItem,
+  ): TreeNodeItem[] =>
+    list.map((node) =>
+      node.id === parentId
+        ? { ...node, children: [...node.children, child] }
+        : { ...node, children: appendChild(node.children, parentId, child) },
+    );
+
+  const createNode = (name: string): TreeNodeItem => ({
+    id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    name,
+    children: [],
+  });
+
+  const handleNodeSheetConfirm = (name: string) => {
+    if (!nodeSheetMode) return;
+
+    if (nodeSheetMode.kind === "create-root") {
+      const next = createNode(name);
+      setNodes((prev) => [...prev, next]);
+      setSelectedNodeId((prev) => prev ?? next.id);
+    } else {
+      setNodes((prev) => renameNode(prev, nodeSheetMode.nodeId, name));
+    }
+
+    setNodeSheetMode(null);
+  };
+
+  const handleAddChildNode = (parentId: string) => {
+    const parent = findNode(nodes, parentId);
+    if (!parent) return;
+    const isRoot = nodes.some((n) => n.id === parentId);
+    const separator = isRoot ? " " : ".";
+    const newName = `${parent.name}${separator}${parent.children.length + 1}`;
+    setNodes((prev) => appendChild(prev, parentId, createNode(newName)));
+  };
+
+  const sheetTitle =
+    nodeSheetMode?.kind === "rename" ? "기능 이름 수정" : "기능 추가하기";
+  const sheetInitialName =
+    nodeSheetMode?.kind === "rename" ? nodeSheetMode.initialName : "";
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 flex flex-col overflow-y-auto bg-white pb-28"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+    >
+      <TreeCreateTopSection
+        questionTitle={questionTitle}
+        questionDescription={questionDescription}
+        onOpenQuestionEditor={() => setIsQuestionEditorOpen(true)}
+      />
+      <TreeCreateOptionSection
+        nodes={nodes}
+        selectedNodeId={selectedNodeId}
+        isManageMode={isManageMode}
+        onOpenNodeEditor={() => setNodeSheetMode({ kind: "create-root" })}
+        onSelectNode={setSelectedNodeId}
+        onEditNode={(nodeId) => {
+          const target = findNode(nodes, nodeId);
+          if (!target) return;
+          setNodeSheetMode({ kind: "rename", nodeId, initialName: target.name });
+        }}
+        onAddChildNode={handleAddChildNode}
+        onToggleManageMode={() => setIsManageMode((prev) => !prev)}
+        onDeleteNode={(nodeId) => {
+          setNodes((prev) => deleteNode(prev, nodeId));
+          setSelectedNodeId((prev) => (prev === nodeId ? null : prev));
+        }}
+      />
+      <TreeCreateBottomCTA
+        isCompleteDisabled={isCompleteDisabled}
+        onCancel={onClose}
+        onComplete={() => {
+          updateQuestion(questionId, {
+            typeId: "tree",
+            title: questionTitle,
+            description: questionDescription,
+            nodes,
+          });
+          onClose();
+        }}
+      />
+
+      <TreeNodeAddSheet
+        open={nodeSheetMode !== null}
+        title={nodeSheetMode?.kind === "rename" ? "기능 이름 수정" : "기능 추가하기"}
+        initialName={nodeSheetMode?.kind === "rename" ? nodeSheetMode.initialName : ""}
+        onClose={() => setNodeSheetMode(null)}
+        onConfirm={handleNodeSheetConfirm}
+      />
+
+      <AnimatePresence>
+        {isQuestionEditorOpen && (
+          <TreeQuestionEditorOverlay
+            initialTitle={questionTitle}
+            initialDescription={questionDescription}
+            onClose={() => setIsQuestionEditorOpen(false)}
+            onSave={({ title, description }) => {
+              setQuestionTitle(title);
+              setQuestionDescription(description);
+              setIsQuestionEditorOpen(false);
+            }}
+          />
+        )}
+      </AnimatePresence>
+    </motion.div>
+  );
+}

--- a/src/features/test-tree/ui/TreeCreatePage.tsx
+++ b/src/features/test-tree/ui/TreeCreatePage.tsx
@@ -161,9 +161,10 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
       />
 
       <TreeNodeAddSheet
+        key={nodeSheetMode ? `${nodeSheetMode.kind}-${'nodeId' in nodeSheetMode ? nodeSheetMode.nodeId : 'root'}` : 'closed'}
         open={nodeSheetMode !== null}
-        title={nodeSheetMode?.kind === "rename" ? "기능 이름 수정" : "기능 추가하기"}
-        initialName={nodeSheetMode?.kind === "rename" ? nodeSheetMode.initialName : ""}
+        title={sheetTitle}
+        initialName={sheetInitialName}
         onClose={() => setNodeSheetMode(null)}
         onConfirm={handleNodeSheetConfirm}
       />

--- a/src/features/test-tree/ui/TreeCreateTopSection.tsx
+++ b/src/features/test-tree/ui/TreeCreateTopSection.tsx
@@ -1,0 +1,54 @@
+import { Border, Top } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+
+interface TreeCreateTopSectionProps {
+  questionTitle: string;
+  questionDescription: string;
+  onOpenQuestionEditor: () => void;
+}
+
+export function TreeCreateTopSection({
+  questionTitle,
+  questionDescription,
+  onOpenQuestionEditor,
+}: TreeCreateTopSectionProps) {
+  const hasQuestionTitle = questionTitle.trim().length > 0;
+  const displayTitle = hasQuestionTitle ? questionTitle : "제목이 없어요";
+  const displayDescription =
+    questionDescription.trim().length > 0 ? questionDescription : "설명이 없어요";
+
+  return (
+    <>
+      <Top
+        title={
+          <Top.TitleParagraph size={22} color={adaptive.grey900}>
+            {displayTitle}
+          </Top.TitleParagraph>
+        }
+        subtitleTop={
+          <Top.SubtitleParagraph size={15} color={adaptive.grey500}>
+            트리 테스트
+          </Top.SubtitleParagraph>
+        }
+        subtitleBottom={
+          <Top.SubtitleParagraph size={15}>
+            {displayDescription}
+          </Top.SubtitleParagraph>
+        }
+        lower={
+          <Top.LowerButton
+            color={hasQuestionTitle ? "dark" : "primary"}
+            size="small"
+            variant="weak"
+            display="inline"
+            onClick={onOpenQuestionEditor}
+          >
+            {hasQuestionTitle ? "수정하기" : "입력하기"}
+          </Top.LowerButton>
+        }
+      />
+
+      <Border variant="height16" />
+    </>
+  );
+}

--- a/src/features/test-tree/ui/TreeNodeAddSheet.tsx
+++ b/src/features/test-tree/ui/TreeNodeAddSheet.tsx
@@ -64,7 +64,8 @@ export function TreeNodeAddSheet({
         labelOption="sustain"
         value={name}
         placeholder="기능 이름"
-        onChange={(e) => setName(e.target.value)}
+        maxLength={17}
+        onChange={(e) => setName(e.target.value.slice(0, 17))}
         onClear={() => setName("")}
       />
     </BottomSheet>

--- a/src/features/test-tree/ui/TreeNodeAddSheet.tsx
+++ b/src/features/test-tree/ui/TreeNodeAddSheet.tsx
@@ -21,12 +21,10 @@ export function TreeNodeAddSheet({
 
   useEffect(() => {
     if (!open) return;
-    setName(initialName);
     const id = window.setTimeout(() => {
       inputRef.current?.focus();
     }, 0);
     return () => window.clearTimeout(id);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
   const isConfirmDisabled = name.trim().length === 0;

--- a/src/features/test-tree/ui/TreeNodeAddSheet.tsx
+++ b/src/features/test-tree/ui/TreeNodeAddSheet.tsx
@@ -1,0 +1,74 @@
+import { useEffect, useRef, useState } from "react";
+import { BottomSheet, TextField } from "@toss/tds-mobile";
+
+interface TreeNodeAddSheetProps {
+  open: boolean;
+  title?: string;
+  initialName?: string;
+  onClose: () => void;
+  onConfirm: (name: string) => void;
+}
+
+export function TreeNodeAddSheet({
+  open,
+  title = "기능 추가하기",
+  initialName = "",
+  onClose,
+  onConfirm,
+}: TreeNodeAddSheetProps) {
+  const [name, setName] = useState(initialName);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setName(initialName);
+    const id = window.setTimeout(() => {
+      inputRef.current?.focus();
+    }, 0);
+    return () => window.clearTimeout(id);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open]);
+
+  const isConfirmDisabled = name.trim().length === 0;
+
+  const handleClose = () => {
+    setName("");
+    onClose();
+  };
+
+  const handleConfirm = () => {
+    const value = name.trim();
+    setName("");
+    onConfirm(value);
+  };
+
+  return (
+    <BottomSheet
+      header={<BottomSheet.Header>{title}</BottomSheet.Header>}
+      open={open}
+      onClose={handleClose}
+      hasTextField
+      cta={
+        <BottomSheet.CTA
+          color="primary"
+          variant="fill"
+          disabled={isConfirmDisabled}
+          onClick={handleConfirm}
+        >
+          확인
+        </BottomSheet.CTA>
+      }
+    >
+      <TextField.Clearable
+        ref={inputRef}
+        variant="line"
+        label="기능 이름"
+        labelOption="sustain"
+        value={name}
+        placeholder="기능 이름"
+        onChange={(e) => setName(e.target.value)}
+        onClear={() => setName("")}
+      />
+    </BottomSheet>
+  );
+}

--- a/src/features/test-tree/ui/TreeQuestionEditorOverlay.tsx
+++ b/src/features/test-tree/ui/TreeQuestionEditorOverlay.tsx
@@ -1,0 +1,85 @@
+import { useState } from "react";
+import { motion } from "framer-motion";
+import { CTAButton, FixedBottomCTA, TextField, Top } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+
+interface TreeQuestionEditorOverlayProps {
+  initialTitle: string;
+  initialDescription: string;
+  onClose: () => void;
+  onSave: (values: { title: string; description: string }) => void;
+}
+
+export function TreeQuestionEditorOverlay({
+  initialTitle,
+  initialDescription,
+  onClose,
+  onSave,
+}: TreeQuestionEditorOverlayProps) {
+  const [title, setTitle] = useState(initialTitle);
+  const [description, setDescription] = useState(initialDescription);
+
+  const isSaveDisabled = title.trim().length === 0;
+
+  return (
+    <motion.div
+      className="fixed inset-0 z-50 flex flex-col bg-white"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+    >
+      <Top
+        title={
+          <Top.TitleParagraph size={22} color={adaptive.grey900}>
+            질문 입력하기
+          </Top.TitleParagraph>
+        }
+      />
+
+      <main className="flex flex-1 flex-col bg-white">
+        <TextField.Clearable
+          variant="line"
+          label="질문 제목"
+          labelOption="sustain"
+          value={title}
+          placeholder="질문 제목"
+          autoFocus
+          onChange={(e) => setTitle(e.target.value)}
+          onClear={() => setTitle("")}
+        />
+        <TextField.Clearable
+          variant="line"
+          label="설명"
+          labelOption="sustain"
+          value={description}
+          placeholder="설명"
+          prefix="(선택)"
+          onChange={(e) => setDescription(e.target.value)}
+          onClear={() => setDescription("")}
+        />
+      </main>
+
+      <FixedBottomCTA.Double
+        leftButton={
+          <CTAButton color="dark" variant="weak" onClick={onClose}>
+            취소
+          </CTAButton>
+        }
+        rightButton={
+          <CTAButton
+            disabled={isSaveDisabled}
+            onClick={() =>
+              onSave({
+                title: title.trim(),
+                description: description.trim(),
+              })
+            }
+          >
+            저장하기
+          </CTAButton>
+        }
+      />
+    </motion.div>
+  );
+}

--- a/src/features/test-tree/ui/TreeQuestionEditorOverlay.tsx
+++ b/src/features/test-tree/ui/TreeQuestionEditorOverlay.tsx
@@ -45,7 +45,8 @@ export function TreeQuestionEditorOverlay({
           value={title}
           placeholder="질문 제목"
           autoFocus
-          onChange={(e) => setTitle(e.target.value)}
+          maxLength={34}
+          onChange={(e) => setTitle(e.target.value.slice(0, 34))}
           onClear={() => setTitle("")}
         />
         <TextField.Clearable
@@ -55,7 +56,8 @@ export function TreeQuestionEditorOverlay({
           value={description}
           placeholder="설명"
           prefix="(선택)"
-          onChange={(e) => setDescription(e.target.value)}
+          maxLength={50}
+          onChange={(e) => setDescription(e.target.value.slice(0, 50))}
           onClear={() => setDescription("")}
         />
       </main>

--- a/src/features/test-tree/ui/index.ts
+++ b/src/features/test-tree/ui/index.ts
@@ -1,0 +1,5 @@
+export { TreeCreatePage } from "./TreeCreatePage";
+export { TreeCreateTopSection } from "./TreeCreateTopSection";
+export { TreeCreateOptionSection } from "./TreeCreateOptionSection";
+export { TreeCreateBottomCTA } from "./TreeCreateBottomCTA";
+export { TreeQuestionEditorOverlay } from "./TreeQuestionEditorOverlay";


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [x] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #27

## 👩🏻‍💻 작업 사항

- `test-tree` feature 구현 (FSD 구조)
- 트리 노드 추가 / 수정 / 삭제 기능
- 최대 4뎁스 제한 — 마지막 뎁스에서 `+` 버튼 비활성화
- 수정 모드 진입 시 각 노드에 삭제 아이콘 표시
- 트리 질문 생성 퍼널(`TestCreateFunnel`) 연동 및 `QuestionData` 타입 확장

## 📢 기타(공유 사항)

- `routeTree.gen.ts` 변경(로그인 라우트)은 로그인 PR에 포함 예정