### PR TITLE
[FEAT] 테스트 참여 - 척도, ab 테스트, 카드소팅 퍼블리싱

### DIFF
--- a/granite.config.ts
+++ b/granite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     icon: "/vite.svg", // 화면에 노출될 앱의 아이콘 이미지 주소로 바꿔주세요.
   },
   web: {
-    host: "localhost",
+    host: "192.168.219.103",
     port: 5173,
     commands: {
       dev: "vite",

--- a/granite.config.ts
+++ b/granite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     icon: "/vite.svg", // 화면에 노출될 앱의 아이콘 이미지 주소로 바꿔주세요.
   },
   web: {
-    host: "10.50.33.85",
+    host: "localhost",
     port: 5173,
     commands: {
       dev: "vite",

--- a/granite.config.ts
+++ b/granite.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     icon: "/vite.svg", // 화면에 노출될 앱의 아이콘 이미지 주소로 바꿔주세요.
   },
   web: {
-    host: "192.168.219.103",
+    host: "10.50.33.85",
     port: 5173,
     commands: {
       dev: "vite",

--- a/src/features/question-ab/answer/AbAnswerPage.tsx
+++ b/src/features/question-ab/answer/AbAnswerPage.tsx
@@ -1,0 +1,87 @@
+import { useState } from "react";
+import { Badge, Top } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+import type { QuestionAnswerProps } from "@/features/test-participate/model/types";
+import { QUESTION_TYPE_LABEL } from "@/features/test-participate/model/constants";
+
+export function AbAnswerPage({
+  question,
+  answer,
+}: QuestionAnswerProps<"ab">) {
+  const { data } = question;
+  const selected = answer?.selected ?? null;
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  return (
+    <div className="flex flex-col">
+      <Top
+        title={
+          <Top.TitleParagraph size={22} color={adaptive.grey900}>
+            {data.title}
+          </Top.TitleParagraph>
+        }
+        subtitleTop={
+          <Top.SubtitleBadges
+            badges={[{ text: QUESTION_TYPE_LABEL.ab, color: "elephant", variant: "weak" }]}
+          />
+        }
+        subtitleBottom={
+          data.description ? (
+            <Top.SubtitleParagraph size={15}>{data.description}</Top.SubtitleParagraph>
+          ) : undefined
+        }
+        lower={
+          <Top.LowerButton
+            color="dark"
+            size="small"
+            variant="weak"
+            display="inline"
+            onClick={() => setIsExpanded((prev) => !prev)}
+          >
+            {isExpanded ? "작게 보기" : "크게 보기"}
+          </Top.LowerButton>
+        }
+      />
+
+      <div className={`flex ${isExpanded ? "flex-col" : "flex-row"} gap-3 px-4 mt-3`}>
+        {(["A", "B"] as const).map((option) => {
+          const imageUrl = option === "A" ? data.imageUrlA : data.imageUrlB;
+          const isSelected = selected === option;
+          return (
+            <div
+              key={option}
+              className={`relative overflow-hidden ${isExpanded ? "w-full" : "flex-1"}`}
+              style={{
+                aspectRatio: "9/16",
+                borderRadius: 16,
+                boxShadow: isSelected
+                  ? `inset 0 0 0 2px #4265cc`
+                  : `inset 0 0 0 1px ${adaptive.greyOpacity100}`,
+              }}
+            >
+              {imageUrl ? (
+                <img
+                  src={imageUrl}
+                  alt={`${option}안`}
+                  className="absolute inset-0 w-full h-full object-cover"
+                  style={{ borderRadius: 16 }}
+                />
+              ) : (
+                <div
+                  className="absolute inset-0"
+                  style={{ background: adaptive.greyOpacity50 }}
+                />
+              )}
+              <div className="absolute top-3 left-3">
+                <Badge size="small" color="red" variant="fill">
+                  {option}안
+                </Badge>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+    </div>
+  );
+}

--- a/src/features/question-ab/answer/AbSelectionBottomSheet.tsx
+++ b/src/features/question-ab/answer/AbSelectionBottomSheet.tsx
@@ -1,0 +1,98 @@
+import { useEffect, useState } from "react";
+import { BottomSheet, CTAButton, List, ListRow, Checkbox } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+import type { AbQuestionData } from "../model/types";
+
+interface Props {
+  data: AbQuestionData;
+  open: boolean;
+  onClose: () => void;
+  onConfirm: (selected: "A" | "B") => void;
+}
+
+export function AbSelectionBottomSheet({ data, open, onClose, onConfirm }: Props) {
+  const [pending, setPending] = useState<"A" | "B" | null>(null);
+
+  useEffect(() => {
+    if (open) setPending(null);
+  }, [open]);
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      header={<BottomSheet.Header>{data.title}</BottomSheet.Header>}
+      headerDescription={
+        data.description ? (
+          <BottomSheet.HeaderDescription>{data.description}</BottomSheet.HeaderDescription>
+        ) : undefined
+      }
+      cta={
+        <BottomSheet.DoubleCTA
+          leftButton={
+            <CTAButton color="dark" variant="weak" onClick={onClose}>
+              닫기
+            </CTAButton>
+          }
+          rightButton={
+            <CTAButton disabled={pending === null} onClick={() => pending && onConfirm(pending)}>
+              확인
+            </CTAButton>
+          }
+        />
+      }
+    >
+      <div className="flex flex-row gap-3 px-4 mb-2">
+        {(["A", "B"] as const).map((option) => {
+          const imageUrl = option === "A" ? data.imageUrlA : data.imageUrlB;
+          return (
+            <div
+              key={option}
+              className="relative flex-1 overflow-hidden"
+              style={{
+                aspectRatio: "9/16",
+                borderRadius: 16,
+                boxShadow: `inset 0 0 0 1px ${adaptive.greyOpacity100}`,
+              }}
+            >
+              {imageUrl ? (
+                <img
+                  src={imageUrl}
+                  alt={`${option}안`}
+                  className="absolute inset-0 w-full h-full object-cover"
+                />
+              ) : (
+                <div
+                  className="absolute inset-0"
+                  style={{ background: adaptive.greyOpacity50 }}
+                />
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex flex-row px-4 gap-3">
+        {(["A", "B"] as const).map((option) => (
+          <div key={option} className="flex-1">
+            <ListRow
+              role="checkbox"
+              aria-checked={pending === option}
+              onClick={() => setPending(option)}
+              contents={
+                <ListRow.Texts
+                  type="1RowTypeB"
+                  top={`${option}안`}
+                  topProps={{ color: adaptive.grey800 }}
+                />
+              }
+              right={<Checkbox.Circle size={24} checked={pending === option} />}
+              verticalPadding="large"
+              horizontalPadding="small"
+            />
+          </div>
+        ))}
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/features/question-ab/answer/AbSelectionBottomSheet.tsx
+++ b/src/features/question-ab/answer/AbSelectionBottomSheet.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { BottomSheet, CTAButton, ListRow, Checkbox } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import type { AbQuestionData } from "../model/types";
@@ -12,10 +12,12 @@ interface Props {
 
 export function AbSelectionBottomSheet({ data, open, onClose, onConfirm }: Props) {
   const [pending, setPending] = useState<"A" | "B" | null>(null);
+  const [prevOpen, setPrevOpen] = useState(open);
 
-  useEffect(() => {
+  if (prevOpen !== open) {
+    setPrevOpen(open);
     if (open) setPending(null);
-  }, [open]);
+  }
 
   return (
     <BottomSheet

--- a/src/features/question-ab/answer/AbSelectionBottomSheet.tsx
+++ b/src/features/question-ab/answer/AbSelectionBottomSheet.tsx
@@ -23,6 +23,7 @@ export function AbSelectionBottomSheet({ data, open, onClose, onConfirm }: Props
     <BottomSheet
       open={open}
       onClose={onClose}
+      maxHeight={700}
       header={<BottomSheet.Header>{data.title}</BottomSheet.Header>}
       headerDescription={
         data.description ? (

--- a/src/features/question-ab/answer/AbSelectionBottomSheet.tsx
+++ b/src/features/question-ab/answer/AbSelectionBottomSheet.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { BottomSheet, CTAButton, List, ListRow, Checkbox } from "@toss/tds-mobile";
+import { BottomSheet, CTAButton, ListRow, Checkbox } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import type { AbQuestionData } from "../model/types";
 

--- a/src/features/question-ab/answer/index.ts
+++ b/src/features/question-ab/answer/index.ts
@@ -1,0 +1,2 @@
+export { AbAnswerPage } from "./AbAnswerPage";
+export { AbSelectionBottomSheet } from "./AbSelectionBottomSheet";

--- a/src/features/question-cardsort/answer/CardSortAnswerPage.tsx
+++ b/src/features/question-cardsort/answer/CardSortAnswerPage.tsx
@@ -1,0 +1,164 @@
+import { useState } from "react";
+import { Top, Tooltip } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+import type { QuestionAnswerProps } from "@/features/test-participate/model/types";
+import { QUESTION_TYPE_LABEL } from "@/features/test-participate/model/constants";
+
+const SELECTED_BORDER = "#4365cc";
+const SELECTED_BG = "var(--adaptiveCardBgGrey)";
+
+function getCategoryColor(index: number): string {
+  if (index === 0) return adaptive.red500;
+  if (index === 1) return adaptive.green500;
+  if (index === 2) return adaptive.blue500;
+  return adaptive.blue500;
+}
+
+export function CardSortAnswerPage({ question, answer, onChange }: QuestionAnswerProps<"cardsort">) {
+  const { data } = question;
+  const placements = answer?.placements ?? {};
+  const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
+  const [hasInteracted, setHasInteracted] = useState(false);
+  const [pickTooltipDone, setPickTooltipDone] = useState(false);
+
+  const getCardCount = (categoryId: string) =>
+    Object.values(placements).filter((v) => v === categoryId).length;
+
+  const getAssignedIndex = (cardId: string): number | null => {
+    const categoryId = placements[cardId];
+    if (!categoryId) return null;
+    const idx = data.categories.findIndex((c) => c.id === categoryId);
+    return idx >= 0 ? idx : null;
+  };
+
+  const handleCardTap = (cardId: string) => {
+    if (!hasInteracted) setHasInteracted(true);
+    if (selectedCardId === cardId && !pickTooltipDone) setPickTooltipDone(true);
+    setSelectedCardId((prev) => (prev === cardId ? null : cardId));
+  };
+
+  const handleCategoryTap = (categoryId: string) => {
+    if (!selectedCardId) return;
+    if (!pickTooltipDone) setPickTooltipDone(true);
+    onChange({ type: "cardsort", placements: { ...placements, [selectedCardId]: categoryId } });
+    setSelectedCardId(null);
+  };
+
+  return (
+    <div className="flex flex-col">
+      <Top
+        title={
+          <Top.TitleParagraph size={22} color={adaptive.grey900}>
+            {data.title}
+          </Top.TitleParagraph>
+        }
+        subtitleTop={
+          <Top.SubtitleBadges
+            badges={[{ text: QUESTION_TYPE_LABEL.cardsort, color: "elephant", variant: "weak" }]}
+          />
+        }
+        subtitleBottom={
+          data.description ? (
+            <Top.SubtitleParagraph size={15}>{data.description}</Top.SubtitleParagraph>
+          ) : undefined
+        }
+      />
+
+      {selectedCardId !== null && !pickTooltipDone && (
+        <div className="flex justify-center items-end" style={{ height: 52 }}>
+          <Tooltip
+            open
+            message="분류할 곳을 선택해주세요"
+            messageAlign="center"
+            placement="top"
+            size="small"
+            motionVariant="weak"
+          >
+            <span />
+          </Tooltip>
+        </div>
+      )}
+
+      <div className={`flex flex-row gap-3 px-5 ${selectedCardId && !pickTooltipDone ? "mt-2" : "mt-4"}`}>
+        {data.categories.map((category, index) => {
+          const borderColor = selectedCardId ? SELECTED_BORDER : getCategoryColor(index);
+          return (
+            <button
+              key={category.id}
+              className="flex-1 flex flex-col items-center justify-center rounded-2xl"
+              style={{
+                border: `${selectedCardId ? 2 : 1}px solid ${borderColor}`,
+                borderRadius: 14,
+                paddingTop: selectedCardId ? 15 : 16,
+                paddingBottom: selectedCardId ? 15 : 16,
+                background: selectedCardId ? SELECTED_BG : "transparent",
+              }}
+              onClick={() => handleCategoryTap(category.id)}
+            >
+              <span style={{ fontWeight: 700, fontSize: 16, color: adaptive.grey900 }}>
+                {category.label}
+              </span>
+              <span style={{ fontSize: 13, color: adaptive.grey500, marginTop: 4 }}>
+                {getCardCount(category.id)}개
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 px-5 mt-6">
+        {data.cards.map((card) => {
+          const assignedIndex = getAssignedIndex(card.id);
+          const isSelected = selectedCardId === card.id;
+          const isAssigned = assignedIndex !== null;
+
+          let borderColor = adaptive.grey300 as string;
+          if (isSelected) borderColor = SELECTED_BORDER;
+          else if (isAssigned) borderColor = getCategoryColor(assignedIndex);
+
+          return (
+            <button
+              key={card.id}
+              className="flex items-center justify-center"
+              style={{
+                border: `${isSelected ? 2 : 1}px solid ${borderColor}`,
+                borderRadius: 14,
+                paddingTop: isSelected ? 19 : 20,
+                paddingBottom: isSelected ? 19 : 20,
+                background: isAssigned && !isSelected ? SELECTED_BG : isSelected ? SELECTED_BG : "white",
+                opacity: isAssigned && !isSelected ? 0.4 : 1,
+                backdropFilter: "blur(0px)",
+              }}
+              onClick={() => handleCardTap(card.id)}
+            >
+              <span
+                style={{
+                  fontWeight: 600,
+                  fontSize: 15,
+                  color: isAssigned && !isSelected ? adaptive.grey700 : adaptive.grey800,
+                }}
+              >
+                {card.label}
+              </span>
+            </button>
+          );
+        })}
+      </div>
+
+      {!hasInteracted && (
+        <div className="flex justify-center mt-4 mb-2">
+          <Tooltip
+            open
+            message="아래에서 선택해주세요"
+            messageAlign="center"
+            placement="bottom"
+            size="small"
+            motionVariant="weak"
+          >
+            <span />
+          </Tooltip>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/question-cardsort/answer/index.ts
+++ b/src/features/question-cardsort/answer/index.ts
@@ -1,0 +1,1 @@
+export { CardSortAnswerPage } from "./CardSortAnswerPage";

--- a/src/features/question-cardsort/model/index.ts
+++ b/src/features/question-cardsort/model/index.ts
@@ -1,0 +1,1 @@
+export type { CardSortCard, CardSortCategory, CardSortQuestionData } from "./types";

--- a/src/features/question-cardsort/model/types.ts
+++ b/src/features/question-cardsort/model/types.ts
@@ -1,0 +1,17 @@
+export interface CardSortCard {
+  id: string;
+  label: string;
+}
+
+export interface CardSortCategory {
+  id: string;
+  label: string;
+}
+
+export interface CardSortQuestionData {
+  title: string;
+  description: string;
+  cards: CardSortCard[];
+  categories: CardSortCategory[];
+  requireAllPlaced: boolean;
+}

--- a/src/features/question-scale/answer/ScaleAnswerPage.tsx
+++ b/src/features/question-scale/answer/ScaleAnswerPage.tsx
@@ -1,0 +1,107 @@
+import { Asset, List, ListRow, Top } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+import type { QuestionAnswerProps } from "@/features/test-participate/model/types";
+import { QUESTION_TYPE_LABEL } from "@/features/test-participate/model/constants";
+
+export function ScaleAnswerPage({
+  question,
+  answer,
+  onChange,
+}: QuestionAnswerProps<"scale">) {
+  const { data } = question;
+  const selectedValue = answer?.value ?? null;
+
+  return (
+    <div className="flex flex-col">
+      <Top
+        title={
+          <Top.TitleParagraph size={22} color={adaptive.grey900}>
+            {data.title}
+          </Top.TitleParagraph>
+        }
+        subtitleTop={
+          <Top.SubtitleBadges
+            badges={[{ text: QUESTION_TYPE_LABEL.scale, color: "elephant", variant: "weak" }]}
+          />
+        }
+        subtitleBottom={
+          data.description ? (
+            <Top.SubtitleParagraph size={15}>{data.description}</Top.SubtitleParagraph>
+          ) : undefined
+        }
+      />
+
+      {data.imageUrl && (
+        <div className="px-4">
+          <img
+            src={data.imageUrl}
+            alt=""
+            className="w-full object-cover rounded-[16px]"
+            style={{
+              aspectRatio: "16/9",
+              border: `1px solid ${adaptive.greyOpacity100}`,
+            }}
+          />
+        </div>
+      )}
+
+      <div className={`flex flex-row px-4 ${data.imageUrl ? "mt-8" : "mt-3"} ${data.scaleCount === 7 ? "justify-between" : "justify-center gap-3"}`}>
+        {Array.from({ length: data.scaleCount }, (_, i) => i + 1).map((value) => {
+          const isSelected = selectedValue === value;
+          return (
+            <button
+              key={value}
+              type="button"
+              onClick={() => onChange({ type: "scale", value })}
+              className="flex items-center justify-center bg-transparent border-0 p-0 cursor-pointer"
+            >
+              <Asset.Text
+                frameShape={Asset.frameShape.CircleLarge}
+                backgroundColor={isSelected ? "#4265cc" : adaptive.greyOpacity100}
+                style={{
+                  color: isSelected ? "#ffffff" : adaptive.grey600,
+                  fontSize: "15px",
+                  fontWeight: "bold",
+                }}
+                aria-label={`${value}점`}
+              >
+                {String(value)}
+              </Asset.Text>
+            </button>
+          );
+        })}
+      </div>
+
+      {(data.minLabel || data.maxLabel) && (
+        <div className="mt-3">
+          <List>
+            {data.minLabel && (
+              <ListRow
+                contents={
+                  <ListRow.Texts
+                    type="1RowTypeA"
+                    top={`1점: ${data.minLabel}`}
+                    topProps={{ color: adaptive.grey600 }}
+                  />
+                }
+                verticalPadding="small"
+              />
+            )}
+            {data.maxLabel && (
+              <ListRow
+                contents={
+                  <ListRow.Texts
+                    type="1RowTypeA"
+                    top={`${data.scaleCount}점: ${data.maxLabel}`}
+                    topProps={{ color: adaptive.grey600 }}
+                  />
+                }
+                verticalPadding="small"
+              />
+            )}
+          </List>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/features/question-scale/answer/index.ts
+++ b/src/features/question-scale/answer/index.ts
@@ -1,0 +1,1 @@
+export { ScaleAnswerPage } from "./ScaleAnswerPage";

--- a/src/features/test-participate/model/constants.ts
+++ b/src/features/test-participate/model/constants.ts
@@ -16,6 +16,6 @@ export const QUESTION_TYPE_LABEL: Record<QuestionType, string> = {
   tree: "트리 선택",
   fivesec: "5초 테스트",
   scale: "척도",
-  ab: "A/B 선택",
+  ab: "A/B 테스트",
   cardsort: "카드 분류",
 };

--- a/src/features/test-participate/model/index.ts
+++ b/src/features/test-participate/model/index.ts
@@ -2,5 +2,5 @@ export * from "./types";
 export * from "./validation";
 export * from "./useParticipateFunnel";
 export * from "./constants";
-export { MOCK_PARTICIPATE_TEST } from "./mock";
+export { MOCK_PARTICIPATE_TEST, MOCK_PARTICIPATE_TESTS } from "./mock";
 

--- a/src/features/test-participate/model/mock.ts
+++ b/src/features/test-participate/model/mock.ts
@@ -1,6 +1,6 @@
 import type { ParticipateTest } from "./types";
 
-export const MOCK_PARTICIPATE_TEST: ParticipateTest = {
+const MOCK_TEST_1: ParticipateTest = {
   id: 1,
   title: "메이트 샘플 테스트",
   questions: [
@@ -60,6 +60,40 @@ export const MOCK_PARTICIPATE_TEST: ParticipateTest = {
       },
     },
     {
+      id: "q5",
+      type: "scale",
+      data: {
+        title: "이 서비스가 2030 여성으로서 도움이 되고 편리하다고 느껴지셨나요?",
+        description: "1~5점 중에서 생각한 점수를 알려주세요.",
+        scaleCount: 5,
+        minLabel: "전혀 그렇지 않다",
+        maxLabel: "매우 그렇다",
+      },
+    },
+    {
+      id: "q6",
+      type: "scale",
+      data: {
+        title: "전반적인 만족도를 7점 척도로 평가해주세요.",
+        description: "1~7점 중에서 생각한 점수를 알려주세요.",
+        scaleCount: 7,
+        minLabel: "전혀 만족하지 않는다",
+        maxLabel: "매우 만족한다",
+      },
+    },
+    {
+      id: "q7",
+      type: "scale",
+      data: {
+        title: "이 디자인이 브랜드 이미지와 잘 어울린다고 생각하시나요?",
+        description: "1~5점 중에서 생각한 점수를 알려주세요.",
+        scaleCount: 5,
+        minLabel: "전혀 그렇지 않다",
+        maxLabel: "매우 그렇다",
+        imageUrl: "https://static.toss.im/appsintoss/33213/ac1b1d5e-c6d7-4943-9236-fcbd2bc825c0.png",
+      },
+    },
+    {
       id: "q4",
       type: "fivesec",
       data: {
@@ -81,3 +115,63 @@ export const MOCK_PARTICIPATE_TEST: ParticipateTest = {
     },
   ],
 };
+
+const MOCK_TEST_2: ParticipateTest = {
+  id: 2,
+  title: "척도 테스트",
+  questions: [
+    {
+      id: "s1",
+      type: "scale",
+      data: {
+        title: "이 서비스가 전반적으로 사용하기 편리했나요?",
+        description: "1~5점 중에서 생각한 점수를 알려주세요.",
+        scaleCount: 5,
+        minLabel: "개좋다",
+        maxLabel: "별로",
+      },
+    },
+    {
+      id: "s2",
+      type: "scale",
+      data: {
+        title: "이 서비스를 다른 사람에게 추천할 의향이 있나요?",
+        description: "1~7점 중에서 생각한 점수를 알려주세요.",
+        scaleCount: 7,
+        minLabel: "전혀 그렇지 않다",
+        maxLabel: "매우 그렇다",
+      },
+    },
+    {
+      id: "s3",
+      type: "scale",
+      data: {
+        title: "이 디자인이 브랜드 이미지와 잘 어울린다고 생각하시나요?",
+        description: "1~5점 중에서 생각한 점수를 알려주세요.",
+        scaleCount: 5,
+        minLabel: "전혀 그렇지 않다",
+        maxLabel: "매우 그렇다",
+        imageUrl: "https://static.toss.im/appsintoss/33213/ac1b1d5e-c6d7-4943-9236-fcbd2bc825c0.png",
+      },
+    },
+    {
+      id: "s4",
+      type: "scale",
+      data: {
+        title: "이 화면 구성이 목적에 맞게 명확하게 전달되나요?",
+        description: "1~7점 중에서 생각한 점수를 알려주세요.",
+        scaleCount: 7,
+        minLabel: "전혀 명확하지 않다",
+        maxLabel: "매우 명확하다",
+        imageUrl: "https://static.toss.im/appsintoss/33213/ac1b1d5e-c6d7-4943-9236-fcbd2bc825c0.png",
+      },
+    },
+  ],
+};
+
+export const MOCK_PARTICIPATE_TESTS: Record<number, ParticipateTest> = {
+  1: MOCK_TEST_1,
+  2: MOCK_TEST_2,
+};
+
+export const MOCK_PARTICIPATE_TEST = MOCK_TEST_1;

--- a/src/features/test-participate/model/mock.ts
+++ b/src/features/test-participate/model/mock.ts
@@ -106,6 +106,28 @@ const MOCK_TEST_1: ParticipateTest = {
       },
     },
     {
+      id: "cs1",
+      type: "cardsort",
+      data: {
+        title: "카드를 적절한 카테고리로 분류해주세요",
+        description: "각 카드를 하나의 카테고리에 배치해주세요",
+        cards: [
+          { id: "card1", label: "셔츠" },
+          { id: "card2", label: "가디건" },
+          { id: "card3", label: "슬랙스" },
+          { id: "card4", label: "청바지" },
+          { id: "card5", label: "운동화" },
+          { id: "card6", label: "구두" },
+        ],
+        categories: [
+          { id: "cat1", label: "상의" },
+          { id: "cat2", label: "하의" },
+          { id: "cat3", label: "신발" },
+        ],
+        requireAllPlaced: true,
+      },
+    },
+    {
       id: "q4",
       type: "fivesec",
       data: {
@@ -193,9 +215,56 @@ const MOCK_TEST_2: ParticipateTest = {
   ],
 };
 
+const MOCK_TEST_3: ParticipateTest = {
+  id: 3,
+  title: "카드 소팅 테스트",
+  questions: [
+    {
+      id: "cs1",
+      type: "cardsort",
+      data: {
+        title: "카드를 적절한 카테고리로 분류해주세요",
+        description: "각 카드를 하나의 카테고리에 배치해주세요",
+        cards: [
+          { id: "card1", label: "셔츠" },
+          { id: "card2", label: "가디건" },
+          { id: "card3", label: "슬랙스" },
+          { id: "card4", label: "청바지" },
+          { id: "card5", label: "운동화" },
+          { id: "card6", label: "구두" },
+          { id: "card7", label: "청바지" },
+          { id: "card8", label: "운동화" },
+          { id: "card9", label: "구두" },
+          { id: "card10", label: "청바지" },
+          { id: "card11", label: "운동화" },
+          { id: "card12", label: "구두" },
+        ],
+        categories: [
+          { id: "cat1", label: "상의" },
+          { id: "cat2", label: "하의" },
+          { id: "cat3", label: "신발" },
+        ],
+        requireAllPlaced: true,
+      },
+    },
+    {
+      id: "s1",
+      type: "scale",
+      data: {
+        title: "분류 작업이 얼마나 직관적이었나요?",
+        description: "1~5점 중에서 생각한 점수를 알려주세요.",
+        scaleCount: 5,
+        minLabel: "전혀 직관적이지 않다",
+        maxLabel: "매우 직관적이다",
+      },
+    },
+  ],
+};
+
 export const MOCK_PARTICIPATE_TESTS: Record<number, ParticipateTest> = {
   1: MOCK_TEST_1,
   2: MOCK_TEST_2,
+  3: MOCK_TEST_3,
 };
 
 export const MOCK_PARTICIPATE_TEST = MOCK_TEST_1;

--- a/src/features/test-participate/model/mock.ts
+++ b/src/features/test-participate/model/mock.ts
@@ -94,6 +94,18 @@ const MOCK_TEST_1: ParticipateTest = {
       },
     },
     {
+      id: "q8",
+      type: "ab",
+      data: {
+        title: "누가 더 귀엽나요?",
+        description: "솔직하게 답변해 주세요",
+        imageUrlA:
+          "https://static.toss.im/appsintoss/33213/ac1b1d5e-c6d7-4943-9236-fcbd2bc825c0.png",
+        imageUrlB:
+          "https://static.toss.im/appsintoss/33213/ac1b1d5e-c6d7-4943-9236-fcbd2bc825c0.png",
+      },
+    },
+    {
       id: "q4",
       type: "fivesec",
       data: {
@@ -120,6 +132,18 @@ const MOCK_TEST_2: ParticipateTest = {
   id: 2,
   title: "척도 테스트",
   questions: [
+    {
+      id: "ab1",
+      type: "ab",
+      data: {
+        title: "누가 더 귀엽나요?",
+        description: "솔직하게 답변해 주세요",
+        imageUrlA:
+          "https://static.toss.im/appsintoss/33213/ac1b1d5e-c6d7-4943-9236-fcbd2bc825c0.png",
+        imageUrlB:
+          "https://static.toss.im/appsintoss/33213/ac1b1d5e-c6d7-4943-9236-fcbd2bc825c0.png",
+      },
+    },
     {
       id: "s1",
       type: "scale",

--- a/src/features/test-participate/model/types.ts
+++ b/src/features/test-participate/model/types.ts
@@ -4,26 +4,9 @@ import type { TreeQuestionData } from "@/features/question-tree/model/types";
 import type { FivesecQuestionData } from "@/features/question-fivesec/model/types";
 import type { ScaleQuestionData } from "@/features/question-scale/model/types";
 import type { AbQuestionData } from "@/features/question-ab/model/types";
+import type { CardSortQuestionData } from "@/features/question-cardsort/model/types";
 
-export type { ScaleQuestionData, AbQuestionData };
-
-export interface CardSortCard {
-  id: string;
-  label: string;
-}
-
-export interface CardSortCategory {
-  id: string;
-  label: string;
-}
-
-export interface CardSortQuestionData {
-  title: string;
-  description: string;
-  cards: CardSortCard[];
-  categories: CardSortCategory[];
-  requireAllPlaced: boolean;
-}
+export type { ScaleQuestionData, AbQuestionData, CardSortQuestionData };
 
 export type ParticipateQuestion =
   | { id: string; type: "subjective"; data: SubjectiveQuestionData }

--- a/src/features/test-participate/model/useParticipateFunnel.ts
+++ b/src/features/test-participate/model/useParticipateFunnel.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from "react";
 import type { Answer, ParticipateQuestion } from "./types";
+import { isAnswerValid } from "./validation";
 
 export interface UseParticipateFunnelResult {
   currentIndex: number;
@@ -25,8 +26,10 @@ export function useParticipateFunnel(
   const currentAnswer = answers[currentQuestion.id];
   const isFirst = currentIndex === 0;
   const isLast = currentIndex === questions.length - 1;
-  // 답변 UI는 비어있는 상태이므로 항상 true. 유형별 UI 도입 시 isAnswerValid로 교체.
-  const canGoNext = true;
+  const canGoNext =
+    currentQuestion.type === "scale"
+      ? isAnswerValid(currentQuestion, currentAnswer)
+      : true;
 
   const setAnswer = useCallback(
     (answer: Answer) => {

--- a/src/features/test-participate/model/useParticipateFunnel.ts
+++ b/src/features/test-participate/model/useParticipateFunnel.ts
@@ -26,10 +26,17 @@ export function useParticipateFunnel(
   const currentAnswer = answers[currentQuestion.id];
   const isFirst = currentIndex === 0;
   const isLast = currentIndex === questions.length - 1;
-  const canGoNext =
-    currentQuestion.type === "scale"
-      ? isAnswerValid(currentQuestion, currentAnswer)
-      : true;
+  const canGoNext = (() => {
+    if (currentQuestion.type === "scale") return isAnswerValid(currentQuestion, currentAnswer);
+    if (currentQuestion.type === "cardsort" && currentQuestion.data.requireAllPlaced) {
+      const cardsortAnswer = currentAnswer?.type === "cardsort" ? currentAnswer : undefined;
+      return (
+        cardsortAnswer !== undefined &&
+        currentQuestion.data.cards.every((card) => cardsortAnswer.placements[card.id] !== undefined)
+      );
+    }
+    return true;
+  })();
 
   const setAnswer = useCallback(
     (answer: Answer) => {

--- a/src/features/test-participate/ui/ParticipatePage.tsx
+++ b/src/features/test-participate/ui/ParticipatePage.tsx
@@ -1,12 +1,16 @@
 import { useNavigate } from "@tanstack/react-router";
 import { CTAButton, FixedBottomCTA, ProgressBar } from "@toss/tds-mobile";
-import { MOCK_PARTICIPATE_TEST, useParticipateFunnel } from "../model";
+import { MOCK_PARTICIPATE_TEST, MOCK_PARTICIPATE_TESTS, useParticipateFunnel } from "../model";
 import { ROUTES } from "@/shared/constants/routes";
 import { QuestionRenderer } from "./QuestionRenderer";
 
-export function ParticipatePage() {
+interface Props {
+  testId?: number;
+}
+
+export function ParticipatePage({ testId }: Props) {
   const navigate = useNavigate();
-  const test = MOCK_PARTICIPATE_TEST;
+  const test = (testId != null ? MOCK_PARTICIPATE_TESTS[testId] : undefined) ?? MOCK_PARTICIPATE_TEST;
 
   const funnel = useParticipateFunnel(test.questions, () => {
     navigate({ to: ROUTES.DISCOVERY });
@@ -21,7 +25,11 @@ export function ParticipatePage() {
       <ProgressBar progress={progress} size="normal" />
 
       <main className="flex flex-col flex-1">
-        <QuestionRenderer question={currentQuestion} />
+        <QuestionRenderer
+          question={currentQuestion}
+          answer={funnel.currentAnswer}
+          onChange={funnel.setAnswer}
+        />
       </main>
 
       {isFirst ? (

--- a/src/features/test-participate/ui/ParticipatePage.tsx
+++ b/src/features/test-participate/ui/ParticipatePage.tsx
@@ -1,8 +1,10 @@
+import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { CTAButton, FixedBottomCTA, ProgressBar } from "@toss/tds-mobile";
 import { MOCK_PARTICIPATE_TEST, MOCK_PARTICIPATE_TESTS, useParticipateFunnel } from "../model";
 import { ROUTES } from "@/shared/constants/routes";
 import { QuestionRenderer } from "./QuestionRenderer";
+import { AbSelectionBottomSheet } from "@/features/question-ab/answer";
 
 interface Props {
   testId?: number;
@@ -18,7 +20,10 @@ export function ParticipatePage({ testId }: Props) {
 
   const { currentIndex, totalCount, currentQuestion, isFirst, isLast, canGoNext, goNext, goPrev } = funnel;
 
+  const [isAbSheetOpen, setIsAbSheetOpen] = useState(false);
+
   const progress = (currentIndex + 1) / totalCount;
+  const isAbQuestion = currentQuestion.type === "ab";
 
   return (
     <div className="flex flex-col min-h-dvh">
@@ -32,7 +37,30 @@ export function ParticipatePage({ testId }: Props) {
         />
       </main>
 
-      {isFirst ? (
+      {isAbQuestion ? (
+        isFirst ? (
+          <FixedBottomCTA
+            topAccessory="두 가지 안을 확인하고 선택하기를 눌러요"
+            onClick={() => setIsAbSheetOpen(true)}
+          >
+            선택하기
+          </FixedBottomCTA>
+        ) : (
+          <FixedBottomCTA.Double
+            topAccessory="두 가지 안을 확인하고 선택하기를 눌러요"
+            leftButton={
+              <CTAButton color="dark" variant="weak" onClick={goPrev}>
+                이전
+              </CTAButton>
+            }
+            rightButton={
+              <CTAButton onClick={() => setIsAbSheetOpen(true)}>
+                {isLast ? "완료하기" : "선택하기"}
+              </CTAButton>
+            }
+          />
+        )
+      ) : isFirst ? (
         <FixedBottomCTA disabled={!canGoNext} onClick={goNext}>
           다음
         </FixedBottomCTA>
@@ -48,6 +76,19 @@ export function ParticipatePage({ testId }: Props) {
               {isLast ? "완료하기" : "다음"}
             </CTAButton>
           }
+        />
+      )}
+
+      {isAbQuestion && currentQuestion.type === "ab" && (
+        <AbSelectionBottomSheet
+          data={currentQuestion.data}
+          open={isAbSheetOpen}
+          onClose={() => setIsAbSheetOpen(false)}
+          onConfirm={(selected) => {
+            funnel.setAnswer({ type: "ab", selected });
+            setIsAbSheetOpen(false);
+            goNext();
+          }}
         />
       )}
     </div>

--- a/src/features/test-participate/ui/QuestionRenderer.tsx
+++ b/src/features/test-participate/ui/QuestionRenderer.tsx
@@ -1,17 +1,27 @@
-import type { ParticipateQuestion } from "../model/types";
+import type { Answer, AnswerOf, ParticipateQuestion } from "../model/types";
+import { ScaleAnswerPage } from "@/features/question-scale/answer";
 import { EmptyAnswerView } from "./EmptyAnswerView";
 
 interface Props {
   question: ParticipateQuestion;
+  answer: Answer | undefined;
+  onChange: (answer: Answer) => void;
 }
 
-export function QuestionRenderer({ question }: Props) {
+export function QuestionRenderer({ question, answer, onChange }: Props) {
   switch (question.type) {
+    case "scale":
+      return (
+        <ScaleAnswerPage
+          question={question}
+          answer={answer as AnswerOf<"scale"> | undefined}
+          onChange={onChange as (answer: AnswerOf<"scale">) => void}
+        />
+      );
     case "subjective":
     case "multiple":
     case "tree":
     case "fivesec":
-    case "scale":
     case "ab":
     case "cardsort":
       return <EmptyAnswerView question={question} />;

--- a/src/features/test-participate/ui/QuestionRenderer.tsx
+++ b/src/features/test-participate/ui/QuestionRenderer.tsx
@@ -1,5 +1,6 @@
 import type { Answer, AnswerOf, ParticipateQuestion } from "../model/types";
 import { ScaleAnswerPage } from "@/features/question-scale/answer";
+import { AbAnswerPage } from "@/features/question-ab/answer";
 import { EmptyAnswerView } from "./EmptyAnswerView";
 
 interface Props {
@@ -23,6 +24,13 @@ export function QuestionRenderer({ question, answer, onChange }: Props) {
     case "tree":
     case "fivesec":
     case "ab":
+      return (
+        <AbAnswerPage
+          question={question}
+          answer={answer as AnswerOf<"ab"> | undefined}
+          onChange={onChange as (answer: AnswerOf<"ab">) => void}
+        />
+      );
     case "cardsort":
       return <EmptyAnswerView question={question} />;
   }

--- a/src/features/test-participate/ui/QuestionRenderer.tsx
+++ b/src/features/test-participate/ui/QuestionRenderer.tsx
@@ -1,6 +1,7 @@
 import type { Answer, AnswerOf, ParticipateQuestion } from "../model/types";
 import { ScaleAnswerPage } from "@/features/question-scale/answer";
 import { AbAnswerPage } from "@/features/question-ab/answer";
+import { CardSortAnswerPage } from "@/features/question-cardsort/answer";
 import { EmptyAnswerView } from "./EmptyAnswerView";
 
 interface Props {
@@ -19,10 +20,6 @@ export function QuestionRenderer({ question, answer, onChange }: Props) {
           onChange={onChange as (answer: AnswerOf<"scale">) => void}
         />
       );
-    case "subjective":
-    case "multiple":
-    case "tree":
-    case "fivesec":
     case "ab":
       return (
         <AbAnswerPage
@@ -32,6 +29,17 @@ export function QuestionRenderer({ question, answer, onChange }: Props) {
         />
       );
     case "cardsort":
+      return (
+        <CardSortAnswerPage
+          question={question}
+          answer={answer as AnswerOf<"cardsort"> | undefined}
+          onChange={onChange as (answer: AnswerOf<"cardsort">) => void}
+        />
+      );
+    case "subjective":
+    case "multiple":
+    case "tree":
+    case "fivesec":
       return <EmptyAnswerView question={question} />;
   }
 }

--- a/src/routes/test/participate.$testId.tsx
+++ b/src/routes/test/participate.$testId.tsx
@@ -2,5 +2,8 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ParticipatePage } from "@/features/test-participate/ui";
 
 export const Route = createFileRoute("/test/participate/$testId")({
-  component: ParticipatePage,
+  component: function ParticipateRoute() {
+    const { testId } = Route.useParams();
+    return <ParticipatePage testId={Number(testId)} />;
+  },
 });


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [x] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #35

## 👩🏻‍💻 작업 사항

### 척도 답변 UI (question-scale/answer)
- 1~N점 척도 선택 UI 구현
- 선택 시 하이라이트 및 라벨 표시

### A/B 테스트 답변 UI (question-ab/answer)
- A/B 이미지 비교 선택 UI 구현
- BottomSheet를 활용한 상세 선택 흐름 구현

### 카드소팅 답변 UI (question-cardsort/answer)
- 카드 선택 → 카테고리 배치 인터랙션 구현
- 최초 진입 시 "아래에서 선택해주세요" 툴팁 표시
- 카드 선택 후 "분류할 곳을 선택해주세요" 툴팁 표시 (최초 1회)
- 카테고리별 색상 구분 및 배치된 카드 수 표시
- requireAllPlaced 옵션 시 전체 배치 완료 전 다음 버튼 비활성화

## 📢 기타(공유 사항)
gh pr create --title "[FEAT] 테스트 참여 - 척도, ab 테스트, 카드소팅 퍼블리싱" --body-file /tmp/pr_body.md