### PR TITLE
[FIX] 트리 테스트 생성 / 참여 수정 사항 반영

### DIFF
--- a/src/features/question-tree/answer/TreeAnswerPage.tsx
+++ b/src/features/question-tree/answer/TreeAnswerPage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { ListRow } from "@toss/tds-mobile";
+import { ListRow, Checkbox } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import type { QuestionAnswerProps } from "@/features/test-participate/model/types";
 import { QUESTION_TYPE_LABEL } from "@/features/test-participate/model/constants";
@@ -26,7 +26,7 @@ export function TreeAnswerPage({ question, answer, onChange }: QuestionAnswerPro
   return (
     <>
       <QuestionHeader categoryLabel={QUESTION_TYPE_LABEL.tree} title={title} description={description} />
-      <div className="mx-4">
+      <div>
         {nodes.map((node) => (
           <TreeNodeRow
             key={node.id}
@@ -72,48 +72,37 @@ function TreeNodeRow({ node, depth, expandedIds, selectedNodeId, onToggleExpand,
         tabIndex={0}
         onClick={handleClick}
         onKeyDown={(e) => e.key === "Enter" && handleClick()}
-        className={`active:scale-[0.98] transition-transform cursor-pointer${depth >= 3 ? " mx-4" : ""}`}
-        style={{
-          backgroundColor: isSelected ? adaptive.blue50 : undefined,
-          borderRadius: 12,
-        }}
+        className="active:scale-[0.98] transition-transform cursor-pointer"
+        style={{ paddingLeft: depth * 16 }}
       >
         <ListRow
-          left={renderDepthIcon(depth)}
-          contents={<ListRow.Texts type={textRowTypeFor(depth)} top={node.name} topProps={{ color: textColorFor(depth) }} />}
+          left={renderDepthIcon(depth, hasChildren, isExpanded)}
+          contents={<ListRow.Texts type={textRowTypeFor(depth)} top={node.name} topProps={{ color: adaptive.grey800 }} />}
+          right={!hasChildren ? <Checkbox.Line size={24} checked={isSelected} /> : undefined}
           verticalPadding="large"
-          arrowType={hasChildren ? (isExpanded ? "up" : "down") : undefined}
         />
       </div>
       {hasChildren && isExpanded
         ? node.children.map((child) => (
-          <TreeNodeRow key={child.id} node={child} depth={depth + 1} expandedIds={expandedIds} selectedNodeId={selectedNodeId} onToggleExpand={onToggleExpand} onSelect={onSelect} />
-        ))
+            <TreeNodeRow key={child.id} node={child} depth={depth + 1} expandedIds={expandedIds} selectedNodeId={selectedNodeId} onToggleExpand={onToggleExpand} onSelect={onSelect} />
+          ))
         : null}
     </>
   );
 }
 
-function renderDepthIcon(depth: number) {
-  switch (depth) {
-    case 0:
-      return <ListRow.AssetImage src="https://static.toss.im/2d-emojis/png/4x/u1F4C1.png" shape="squircle" scale={0.66} backgroundColor={adaptive.greyOpacity100} size="xsmall" />;
-    case 1:
-      return <ListRow.AssetIcon name="icon-document-lines-blue" backgroundColor={adaptive.greyOpacity100} />;
-    case 2:
-      return <ListRow.AssetIcon size="xsmall" shape="original" name="icon-system-arrow-right-outlined" />;
-    default:
-      return <ListRow.AssetIcon size="xsmall" shape="original" name="icon-arrow-down-mono" color={adaptive.grey700} />;
+function renderDepthIcon(depth: number, hasChildren: boolean, isExpanded: boolean) {
+  if (depth === 0) {
+    return <ListRow.AssetIcon name="icon-folder" backgroundColor={adaptive.greyOpacity100} />;
   }
+  if (!hasChildren) {
+    return <ListRow.AssetIcon size="xsmall" shape="original" name="icon-arrow-solid-down-mono" color="transparent" />;
+  }
+  return <ListRow.AssetIcon size="xsmall" shape="original" name={isExpanded ? "icon-arrow-increase-mono" : "icon-arrow-solid-down-mono"} color={adaptive.grey300} />;
 }
 
 function textRowTypeFor(depth: number): "1RowTypeA" | "1RowTypeB" | "1RowTypeC" {
   if (depth === 0) return "1RowTypeC";
   if (depth >= 3) return "1RowTypeA";
   return "1RowTypeB";
-}
-
-function textColorFor(depth: number) {
-  if (depth >= 3) return adaptive.grey700;
-  return adaptive.grey800;
 }

--- a/src/features/question-tree/create/TreeCreatePage.tsx
+++ b/src/features/question-tree/create/TreeCreatePage.tsx
@@ -37,7 +37,9 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
   const [nodeSheetMode, setNodeSheetMode] = useState<NodeSheetMode | null>(null);
 
   const isCompleteDisabled =
-    questionTitle.trim().length === 0 || nodes.length === 0;
+    questionTitle.trim().length === 0 ||
+    nodes.length === 0 ||
+    nodes.some((node) => node.children.length === 0);
 
   const findNode = (
     list: TreeNodeItem[],

--- a/src/features/test-participate/model/mock.ts
+++ b/src/features/test-participate/model/mock.ts
@@ -33,7 +33,14 @@ const MOCK_TEST_1: ParticipateTest = {
         title: "내 프로필 사진을 수정하려면 어디로 가야할까요?",
         description: "",
         nodes: [
-          { id: "n1", name: "홈", children: [] },
+          {
+            id: "n1",
+            name: "홈",
+            children: [
+              { id: "n1-1", name: "프로필", children: [] },
+              { id: "n1-2", name: "알림", children: [] },
+            ],
+          },
           {
             id: "n2",
             name: "송금",
@@ -47,16 +54,30 @@ const MOCK_TEST_1: ParticipateTest = {
                     id: "n2-2-1",
                     name: "자동 이체 설정",
                     children: [
-                      { id: "n2-2-1-1", name: "마지막 뎁스", children: [] },
-                      { id: "n2-2-1-2", name: "마지막 뎁스", children: [] },
+                      { id: "n2-2-1-1", name: "이체 주기 설정", children: [] },
+                      { id: "n2-2-1-2", name: "이체 금액 설정", children: [] },
                     ],
                   },
                 ],
               },
             ],
           },
-          { id: "n3", name: "투자", children: [] },
-          { id: "n4", name: "설정", children: [] },
+          {
+            id: "n3",
+            name: "투자",
+            children: [
+              { id: "n3-1", name: "국내 주식", children: [] },
+              { id: "n3-2", name: "해외 주식", children: [] },
+            ],
+          },
+          {
+            id: "n4",
+            name: "설정",
+            children: [
+              { id: "n4-1", name: "계정 설정", children: [] },
+              { id: "n4-2", name: "보안 설정", children: [] },
+            ],
+          },
         ],
       },
     },


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [x] 버그 수정
-   [x] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #42

## 👩🏻‍💻 작업 사항

**트리 테스트 생성**
- 루트 노드가 최소 1개의 자식을 가져야 완료 버튼 활성화되도록 수정

**트리 테스트 참여 UI**
- 오른쪽 아코디언 화살표 아이콘 제거
- 리프 노드(선택 가능한 노드)에만 체크박스 표시
- 확장/축소 상태는 왼쪽 아이콘으로 표시
- 루트 노드 아이콘 folder 아이콘으로 변경
- 선택 시 배경색 제거, 체크박스로만 선택 상태 표시
- 뎁스별 들여쓰기 적용 (16px * depth)
- 텍스트 컬러 뎁스 무관하게 grey800으로 통일

**Mock 데이터**
- 자식 없던 루트 노드(`홈`, `투자`, `설정`) 각각 자식 추가

## 📢 기타(공유 사항)
없음