### PR TITLE
[FIX] 테스트 미리보기 리스트 row 공통화

### DIFF
--- a/src/features/question-scale/create/ScaleCreatePage.tsx
+++ b/src/features/question-scale/create/ScaleCreatePage.tsx
@@ -4,6 +4,7 @@ import { Asset, Border } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { useTestCreateForm } from "@/features/test-create/model/useTestCreateForm";
 import { QuestionCreateTopSection } from "@/features/test-create/ui/QuestionCreateTopSection";
+import { TesterPreviewListRow } from "@/features/test-create/ui/TesterPreviewListRow";
 import { ScaleCreateBottomCTA } from "./ScaleCreateBottomCTA";
 import { ScaleCreateOptionSection } from "./ScaleCreateOptionSection";
 import { ScaleQuestionEditorOverlay } from "./ScaleQuestionEditorOverlay";
@@ -103,6 +104,7 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
           )
         }
       />
+      <TesterPreviewListRow />
       <ScaleCreateOptionSection
         scaleCount={scaleCount}
         minLabel={minLabel}

--- a/src/features/test-create/ui/TestRegisterStep.tsx
+++ b/src/features/test-create/ui/TestRegisterStep.tsx
@@ -13,6 +13,7 @@ import {
 import { adaptive } from "@toss/tds-colors";
 import { QuestionTypeSelectSheet } from "./QuestionTypeSelectSheet";
 import { QuestionManageSheet } from "./QuestionManageSheet";
+import { TesterPreviewListRow } from "./TesterPreviewListRow";
 import {
   QUESTION_TYPES,
   CATEGORIES,
@@ -231,29 +232,7 @@ export function TestRegisterStep({
         ) : (
           <div className="flex flex-col flex-1 pb-4">
             <Spacing size={16} />
-            <ListRow
-              style={{
-                backgroundColor: "var(--adaptiveCardBgGrey)",
-                backdropFilter: "blur(0px)",
-                borderRadius: "999px",
-                opacity: 1,
-                margin: "0 20px",
-              }}
-              left={
-                <ListRow.AssetIcon
-                  name="icon-phone"
-                  backgroundColor={adaptive.greyOpacity100}
-                />
-              }
-              contents={
-                <ListRow.Texts
-                  type="1RowTypeB"
-                  top="실제 테스터에게 보이는 화면이에요"
-                  topProps={{ color: adaptive.grey700 }}
-                />
-              }
-              horizontalPadding="small"
-            />
+            <TesterPreviewListRow />
             <Top
               title={
                 <Top.TitleParagraph size={22} color={adaptive.grey900}>

--- a/src/features/test-create/ui/TesterPreviewListRow.tsx
+++ b/src/features/test-create/ui/TesterPreviewListRow.tsx
@@ -1,0 +1,43 @@
+import { Border, ListRow } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+
+interface TesterPreviewListRowProps {
+  hasBottomContent?: boolean;
+  onClick?: () => void;
+}
+
+export function TesterPreviewListRow({
+  hasBottomContent = true,
+  onClick,
+}: TesterPreviewListRowProps) {
+  return (
+    <div>
+      <ListRow
+        as={onClick ? "button" : undefined}
+        className={onClick ? "w-full text-left" : undefined}
+        left={
+          <ListRow.AssetIcon
+            size="medium"
+            name="icon-phone-appintoss"
+            backgroundColor={adaptive.grey100}
+          />
+        }
+        contents={
+          <ListRow.Texts
+            type="2RowTypeF"
+            top="테스터 화면을 보고 싶다면"
+            topProps={{ color: adaptive.grey500 }}
+            bottom="테스트 미리보기"
+            bottomProps={{ color: adaptive.grey800, fontWeight: "bold" }}
+          />
+        }
+        verticalPadding="large"
+        horizontalPadding="medium"
+        onClick={onClick}
+      />
+      {hasBottomContent ? (
+        <Border variant="full" color={adaptive.opacity300} />
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/test-create/ui/index.ts
+++ b/src/features/test-create/ui/index.ts
@@ -8,3 +8,4 @@ export { QuestionManageSheet } from './QuestionManageSheet';
 export { BasicInfoEditPage } from './BasicInfoEditPage';
 export { ServiceDescriptionEditPage } from './ServiceDescriptionEditPage';
 export { TestImageEditPage } from './TestImageEditPage';
+export { TesterPreviewListRow } from './TesterPreviewListRow';


### PR DESCRIPTION
## 작업 내용
- 테스트 미리보기 안내 ListRow 공통 컴포넌트 추가
- 테스트 등록 화면에서 공통 컴포넌트 사용
- 척도 질문 생성 화면 divider 아래에 임시 노출

## 관련 이슈
- #57 

## 검증
- ./node_modules/.bin/tsc --noEmit