### PR TITLE
[FIX] UT 후 질문 추가 공통 영역 수정

### DIFF
--- a/src/features/question-ab/create/AbCreatePage.tsx
+++ b/src/features/question-ab/create/AbCreatePage.tsx
@@ -1,12 +1,11 @@
 import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { openCamera, fetchAlbumPhotos, OpenCameraPermissionError, FetchAlbumPhotosPermissionError } from "@apps-in-toss/web-framework";
 import { useTestCreateForm } from "@/features/test-create/model/useTestCreateForm";
 import { PhotoSelectSheet } from "@/features/test-create/ui/PhotoSelectSheet";
 import { QuestionCreateTopSection } from "@/features/test-create/ui/QuestionCreateTopSection";
 import { AbCreateBottomCTA } from "./AbCreateBottomCTA";
 import { AbCreateOptionSection } from "./AbCreateOptionSection";
-import { AbQuestionEditorOverlay } from "./AbQuestionEditorOverlay";
 
 interface AbCreatePageProps {
   questionId: string;
@@ -18,9 +17,11 @@ export function AbCreatePage({ questionId, onClose }: AbCreatePageProps) {
   const existing = questions.find((q) => q.id === questionId)?.data;
   const existingAb = existing?.typeId === "ab" ? existing : null;
 
-  const [isQuestionEditorOpen, setIsQuestionEditorOpen] = useState(false);
   const [questionTitle, setQuestionTitle] = useState(existingAb?.title ?? "");
   const [questionDescription, setQuestionDescription] = useState(existingAb?.description ?? "");
+  const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState(
+    (existingAb?.title ?? "").trim().length > 0,
+  );
   const [imageUrlA, setImageUrlA] = useState(existingAb?.imageUrlA ?? "");
   const [imageUrlB, setImageUrlB] = useState(existingAb?.imageUrlB ?? "");
   const [activeSlot, setActiveSlot] = useState<"a" | "b" | null>(null);
@@ -75,33 +76,41 @@ export function AbCreatePage({ questionId, onClose }: AbCreatePageProps) {
       transition={{ duration: 0.2 }}
     >
       <QuestionCreateTopSection
+        questionType="A/B 테스트"
         questionTitle={questionTitle}
         questionDescription={questionDescription}
-        onOpenQuestionEditor={() => setIsQuestionEditorOpen(true)}
-        subtitle="A/B 테스트"
+        onChangeTitle={setQuestionTitle}
+        onChangeDescription={setQuestionDescription}
+        isInputCompleted={isQuestionInputCompleted}
+        onConfirmInput={() => setIsQuestionInputCompleted(true)}
+        onClose={onClose}
       />
-      <AbCreateOptionSection
-        imageUrlA={imageUrlA}
-        imageUrlB={imageUrlB}
-        onUploadA={() => setActiveSlot("a")}
-        onUploadB={() => setActiveSlot("b")}
-        onRemoveA={() => setImageUrlA("")}
-        onRemoveB={() => setImageUrlB("")}
-      />
-      <AbCreateBottomCTA
-        isCompleteDisabled={isCompleteDisabled}
-        onCancel={onClose}
-        onComplete={() => {
-          updateQuestion(questionId, {
-            typeId: "ab",
-            title: questionTitle,
-            description: questionDescription,
-            imageUrlA,
-            imageUrlB,
-          });
-          onClose();
-        }}
-      />
+      {isQuestionInputCompleted && (
+        <>
+          <AbCreateOptionSection
+            imageUrlA={imageUrlA}
+            imageUrlB={imageUrlB}
+            onUploadA={() => setActiveSlot("a")}
+            onUploadB={() => setActiveSlot("b")}
+            onRemoveA={() => setImageUrlA("")}
+            onRemoveB={() => setImageUrlB("")}
+          />
+          <AbCreateBottomCTA
+            isCompleteDisabled={isCompleteDisabled}
+            onCancel={onClose}
+            onComplete={() => {
+              updateQuestion(questionId, {
+                typeId: "ab",
+                title: questionTitle,
+                description: questionDescription,
+                imageUrlA,
+                imageUrlB,
+              });
+              onClose();
+            }}
+          />
+        </>
+      )}
 
       <PhotoSelectSheet
         open={activeSlot !== null}
@@ -109,21 +118,6 @@ export function AbCreatePage({ questionId, onClose }: AbCreatePageProps) {
         onCamera={handleCamera}
         onAlbum={handleAlbum}
       />
-
-      <AnimatePresence>
-        {isQuestionEditorOpen && (
-          <AbQuestionEditorOverlay
-            initialTitle={questionTitle}
-            initialDescription={questionDescription}
-            onClose={() => setIsQuestionEditorOpen(false)}
-            onSave={({ title, description }) => {
-              setQuestionTitle(title);
-              setQuestionDescription(description);
-              setIsQuestionEditorOpen(false);
-            }}
-          />
-        )}
-      </AnimatePresence>
     </motion.div>
   );
 }

--- a/src/features/question-cardsort/create/CardSortCreatePage.tsx
+++ b/src/features/question-cardsort/create/CardSortCreatePage.tsx
@@ -1,12 +1,11 @@
 import { useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { motion } from "framer-motion";
 import { useTestCreateForm } from "@/features/test-create/model/useTestCreateForm";
 import type { CardSortCard, CardSortCategory } from "../model";
 import { CardSortCreateBottomCTA } from "./CardSortCreateBottomCTA";
 import { CardSortCreateOptionSection } from "./CardSortCreateOptionSection";
 import { QuestionCreateTopSection } from "@/features/test-create/ui/QuestionCreateTopSection";
 import { CardSortItemBottomSheet } from "./CardSortItemBottomSheet";
-import { CardSortQuestionEditorOverlay } from "./CardSortQuestionEditorOverlay";
 
 interface CardSortCreatePageProps {
   questionId: string;
@@ -22,9 +21,11 @@ export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePagePr
   const existing = questions.find((q) => q.id === questionId)?.data;
   const existingCardSort = existing?.typeId === "card" ? existing : null;
 
-  const [isQuestionEditorOpen, setIsQuestionEditorOpen] = useState(false);
   const [questionTitle, setQuestionTitle] = useState(existingCardSort?.title ?? "");
   const [questionDescription, setQuestionDescription] = useState(existingCardSort?.description ?? "");
+  const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState(
+    (existingCardSort?.title ?? "").trim().length > 0,
+  );
   const [categories, setCategories] = useState<CardSortCategory[]>(existingCardSort?.categories ?? []);
   const [cards, setCards] = useState<CardSortCard[]>(existingCardSort?.cards ?? []);
 
@@ -92,36 +93,44 @@ export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePagePr
       transition={{ duration: 0.2 }}
     >
       <QuestionCreateTopSection
+        questionType="카드 소팅"
         questionTitle={questionTitle}
         questionDescription={questionDescription}
-        onOpenQuestionEditor={() => setIsQuestionEditorOpen(true)}
-        subtitle="카드 소팅"
+        onChangeTitle={setQuestionTitle}
+        onChangeDescription={setQuestionDescription}
+        isInputCompleted={isQuestionInputCompleted}
+        onConfirmInput={() => setIsQuestionInputCompleted(true)}
+        onClose={onClose}
       />
-      <CardSortCreateOptionSection
-        categories={categories}
-        cards={cards}
-        onAddCategory={handleOpenAddCategory}
-        onEditCategory={handleOpenEditCategory}
-        onDeleteCategory={(id) => setCategories((prev) => prev.filter((c) => c.id !== id))}
-        onAddCard={handleOpenAddCard}
-        onEditCard={handleOpenEditCard}
-        onDeleteCard={(id) => setCards((prev) => prev.filter((c) => c.id !== id))}
-      />
-      <CardSortCreateBottomCTA
-        isCompleteDisabled={isCompleteDisabled}
-        onCancel={onClose}
-        onComplete={() => {
-          updateQuestion(questionId, {
-            typeId: "card",
-            title: questionTitle,
-            description: questionDescription,
-            categories,
-            cards,
-            requireAllPlaced: false,
-          });
-          onClose();
-        }}
-      />
+      {isQuestionInputCompleted && (
+        <>
+          <CardSortCreateOptionSection
+            categories={categories}
+            cards={cards}
+            onAddCategory={handleOpenAddCategory}
+            onEditCategory={handleOpenEditCategory}
+            onDeleteCategory={(id) => setCategories((prev) => prev.filter((c) => c.id !== id))}
+            onAddCard={handleOpenAddCard}
+            onEditCard={handleOpenEditCard}
+            onDeleteCard={(id) => setCards((prev) => prev.filter((c) => c.id !== id))}
+          />
+          <CardSortCreateBottomCTA
+            isCompleteDisabled={isCompleteDisabled}
+            onCancel={onClose}
+            onComplete={() => {
+              updateQuestion(questionId, {
+                typeId: "card",
+                title: questionTitle,
+                description: questionDescription,
+                categories,
+                cards,
+                requireAllPlaced: false,
+              });
+              onClose();
+            }}
+          />
+        </>
+      )}
 
       <CardSortItemBottomSheet
         open={isCategorySheetOpen}
@@ -146,21 +155,6 @@ export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePagePr
         }}
         onConfirm={handleConfirmCard}
       />
-
-      <AnimatePresence>
-        {isQuestionEditorOpen && (
-          <CardSortQuestionEditorOverlay
-            initialTitle={questionTitle}
-            initialDescription={questionDescription}
-            onClose={() => setIsQuestionEditorOpen(false)}
-            onSave={({ title, description }) => {
-              setQuestionTitle(title);
-              setQuestionDescription(description);
-              setIsQuestionEditorOpen(false);
-            }}
-          />
-        )}
-      </AnimatePresence>
     </motion.div>
   );
 }

--- a/src/features/question-fivesec/create/FivesecCreatePage.tsx
+++ b/src/features/question-fivesec/create/FivesecCreatePage.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import {
   openCamera,
   fetchAlbumPhotos,
@@ -26,7 +26,6 @@ import { adaptive } from "@toss/tds-colors";
 import type { MultipleChoiceItem } from "@/features/question-multiple/model/types";
 import { useTestCreateForm } from "@/features/test-create/model/useTestCreateForm";
 import { FivesecMultipleChoiceSection } from "./FivesecMultipleChoiceSection";
-import { FivesecQuestionEditorOverlay } from "./FivesecQuestionEditorOverlay";
 
 interface FivesecCreatePageProps {
   questionId: string;
@@ -39,38 +38,35 @@ export function FivesecCreatePage({
 }: FivesecCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
+  const existingFivesec = existing?.typeId === "fivesec" ? existing : null;
 
-  const [title, setTitle] = useState(
-    existing?.typeId === "fivesec" ? existing.title : "",
+  const [title, setTitle] = useState(existingFivesec?.title ?? "");
+  const [description, setDescription] = useState(existingFivesec?.description ?? "");
+  const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState(
+    (existingFivesec?.title ?? "").trim().length > 0,
   );
-  const [description, setDescription] = useState(
-    existing?.typeId === "fivesec" ? existing.description : "",
-  );
-  const [imageUrl, setImageUrl] = useState(
-    existing?.typeId === "fivesec" ? existing.imageUrl : "",
-  );
+  const [imageUrl, setImageUrl] = useState(existingFivesec?.imageUrl ?? "");
   const duration = 5;
   const [answerExample, setAnswerExample] = useState(
-    existing?.typeId === "fivesec" ? existing.answerExample : "",
+    existingFivesec?.answerExample ?? "",
   );
   const [isMultipleAnswer, setIsMultipleAnswer] = useState(
-    existing?.typeId === "fivesec" ? existing.isMultipleAnswer : false,
+    existingFivesec?.isMultipleAnswer ?? false,
   );
   const [isMultiSelectEnabled, setIsMultiSelectEnabled] = useState(
-    existing?.typeId === "fivesec" ? existing.isMultiSelectEnabled : false,
+    existingFivesec?.isMultiSelectEnabled ?? false,
   );
   const [choices, setChoices] = useState<MultipleChoiceItem[]>(
-    existing?.typeId === "fivesec" ? existing.choices : [],
+    existingFivesec?.choices ?? [],
   );
   const [minSelectCount, setMinSelectCount] = useState(
-    existing?.typeId === "fivesec" ? existing.minSelectCount : 1,
+    existingFivesec?.minSelectCount ?? 1,
   );
   const [maxSelectCount, setMaxSelectCount] = useState(
-    existing?.typeId === "fivesec" ? existing.maxSelectCount : 1,
+    existingFivesec?.maxSelectCount ?? 1,
   );
   const [isChoiceManageMode, setIsChoiceManageMode] = useState(false);
   const [draftChoices, setDraftChoices] = useState<MultipleChoiceItem[]>([]);
-  const [isQuestionEditorOpen, setIsQuestionEditorOpen] = useState(false);
   const [isChoiceSheetOpen, setIsChoiceSheetOpen] = useState(false);
   const [isPhotoSheetOpen, setIsPhotoSheetOpen] = useState(false);
   const [editingChoiceId, setEditingChoiceId] = useState<string | null>(null);
@@ -234,193 +230,185 @@ export function FivesecCreatePage({
       transition={{ duration: 0.2 }}
     >
       <QuestionCreateTopSection
+        questionType="5초 테스트"
         questionTitle={title}
         questionDescription={description}
-        onOpenQuestionEditor={() => setIsQuestionEditorOpen(true)}
-        subtitle="5초 테스트"
+        onChangeTitle={setTitle}
+        onChangeDescription={setDescription}
+        isInputCompleted={isQuestionInputCompleted}
+        onConfirmInput={() => setIsQuestionInputCompleted(true)}
+        onClose={onClose}
       />
 
-      {imageUrl ? (
-        <div className="flex items-start justify-between gap-4 bg-white px-4 py-4">
-          <Text
-            display="block"
-            color={adaptive.grey700}
-            typography="t5"
-            fontWeight="medium"
-          >
-            이미지
-          </Text>
-          <div
-            className="relative h-24 w-42.5 overflow-hidden rounded-2xl"
-            style={{ boxShadow: `inset 0 0 0 1px ${adaptive.greyOpacity100}` }}
-          >
-            <img
-              src={imageUrl}
-              alt="질문 이미지 미리보기"
-              className="h-full w-full object-cover"
-            />
-            <button
-              type="button"
-              onClick={() => setImageUrl("")}
-              className="absolute right-1.5 top-1.5"
-              aria-label="이미지 삭제"
-            >
-              <Asset.Icon
-                frameShape={Asset.frameShape.CircleXSmall}
-                backgroundColor={adaptive.greyOpacity600}
-                name="icon-sweetshop-x-white"
-                scale={0.66}
-                aria-hidden
-              />
-            </button>
-          </div>
-        </div>
-      ) : (
-        <ListRow
-          className=""
-          contents={
-            <ListRow.Texts
-              type="1RowTypeA"
-              top="이미지"
-              topProps={{ color: adaptive.grey700 }}
-            />
-          }
-          right={
-            <Button
-              size="small"
-              color="dark"
-              variant="weak"
-              onClick={() => setIsPhotoSheetOpen(true)}
-            >
-              업로드
-            </Button>
-          }
-          verticalPadding="large"
-        />
-      )}
-
-      {isMultipleAnswer ? (
-        <FivesecMultipleChoiceSection
-          choices={visibleChoices}
-          isChoiceManageMode={isChoiceManageMode}
-          isMultiSelectEnabled={isMultiSelectEnabled}
-          minSelectCount={minSelectCount}
-          maxSelectCount={maxSelectCount}
-          onOpenChoiceCreate={openChoiceCreateSheet}
-          onOpenChoiceEdit={openChoiceEditSheet}
-          onToggleChoiceManageMode={handleToggleChoiceManageMode}
-          onDeleteChoice={(choiceId) =>
-            setActiveChoices(visibleChoices.filter((c) => c.id !== choiceId))
-          }
-          onReorderChoices={(next) => setActiveChoices(next)}
-          onToggleMultipleChoice={requestFormatChange}
-          onToggleMultiSelect={(checked) => {
-            setIsMultiSelectEnabled(checked);
-            if (!checked) {
-              setMinSelectCount(1);
-              setMaxSelectCount(1);
-            } else {
-              const maxChoiceCount = Math.max(choices.length, 1);
-              setMaxSelectCount((current) =>
-                Math.min(Math.max(current, 2), maxChoiceCount),
-              );
-            }
-          }}
-          onChangeMinSelectCount={(value) => {
-            setMinSelectCount(value);
-            if (value > maxSelectCount) setMaxSelectCount(value);
-          }}
-          onChangeMaxSelectCount={(value) => {
-            setMaxSelectCount(value);
-            if (value < minSelectCount) setMinSelectCount(value);
-          }}
-        />
-      ) : (
+      {isQuestionInputCompleted && (
         <>
-          <TextArea
-            variant="box"
-            hasError={false}
-            label="답변 작성"
-            labelOption="sustain"
-            value={answerExample}
-            placeholder="예시 입력창이에요"
-            height={200}
-            readOnly
-          />
+          {imageUrl ? (
+            <div className="flex items-start justify-between gap-4 bg-white px-4 py-4">
+              <Text
+                display="block"
+                color={adaptive.grey700}
+                typography="t5"
+                fontWeight="medium"
+              >
+                이미지
+              </Text>
+              <div
+                className="relative h-24 w-42.5 overflow-hidden rounded-2xl"
+                style={{ boxShadow: `inset 0 0 0 1px ${adaptive.greyOpacity100}` }}
+              >
+                <img
+                  src={imageUrl}
+                  alt="질문 이미지 미리보기"
+                  className="h-full w-full object-cover"
+                />
+                <button
+                  type="button"
+                  onClick={() => setImageUrl("")}
+                  className="absolute right-1.5 top-1.5"
+                  aria-label="이미지 삭제"
+                >
+                  <Asset.Icon
+                    frameShape={Asset.frameShape.CircleXSmall}
+                    backgroundColor={adaptive.greyOpacity600}
+                    name="icon-sweetshop-x-white"
+                    scale={0.66}
+                    aria-hidden
+                  />
+                </button>
+              </div>
+            </div>
+          ) : (
+            <ListRow
+              className=""
+              contents={
+                <ListRow.Texts
+                  type="1RowTypeA"
+                  top="이미지"
+                  topProps={{ color: adaptive.grey700 }}
+                />
+              }
+              right={
+                <Button
+                  size="small"
+                  color="dark"
+                  variant="weak"
+                  onClick={() => setIsPhotoSheetOpen(true)}
+                >
+                  업로드
+                </Button>
+              }
+              verticalPadding="large"
+            />
+          )}
 
-          <Spacing size={12} />
-          <Border />
-          <Spacing size={12} />
+          {isMultipleAnswer ? (
+            <FivesecMultipleChoiceSection
+              choices={visibleChoices}
+              isChoiceManageMode={isChoiceManageMode}
+              isMultiSelectEnabled={isMultiSelectEnabled}
+              minSelectCount={minSelectCount}
+              maxSelectCount={maxSelectCount}
+              onOpenChoiceCreate={openChoiceCreateSheet}
+              onOpenChoiceEdit={openChoiceEditSheet}
+              onToggleChoiceManageMode={handleToggleChoiceManageMode}
+              onDeleteChoice={(choiceId) =>
+                setActiveChoices(visibleChoices.filter((c) => c.id !== choiceId))
+              }
+              onReorderChoices={(next) => setActiveChoices(next)}
+              onToggleMultipleChoice={requestFormatChange}
+              onToggleMultiSelect={(checked) => {
+                setIsMultiSelectEnabled(checked);
+                if (!checked) {
+                  setMinSelectCount(1);
+                  setMaxSelectCount(1);
+                } else {
+                  const maxChoiceCount = Math.max(choices.length, 1);
+                  setMaxSelectCount((current) =>
+                    Math.min(Math.max(current, 2), maxChoiceCount),
+                  );
+                }
+              }}
+              onChangeMinSelectCount={(value) => {
+                setMinSelectCount(value);
+                if (value > maxSelectCount) setMaxSelectCount(value);
+              }}
+              onChangeMaxSelectCount={(value) => {
+                setMaxSelectCount(value);
+                if (value < minSelectCount) setMinSelectCount(value);
+              }}
+            />
+          ) : (
+            <>
+              <TextArea
+                variant="box"
+                hasError={false}
+                label="답변 작성"
+                labelOption="sustain"
+                value={answerExample}
+                placeholder="예시 입력창이에요"
+                height={200}
+                readOnly
+              />
 
-          <ListRow
-            role="switch"
-            aria-checked={isMultipleAnswer}
-            horizontalPadding="small"
-            contents={
-              <ListRow.Texts
-                type="1RowTypeA"
-                top="객관식으로 답변 받기"
-                topProps={{ color: adaptive.grey700 }}
+              <Spacing size={12} />
+              <Border />
+              <Spacing size={12} />
+
+              <ListRow
+                role="switch"
+                aria-checked={isMultipleAnswer}
+                horizontalPadding="small"
+                contents={
+                  <ListRow.Texts
+                    type="1RowTypeA"
+                    top="객관식으로 답변 받기"
+                    topProps={{ color: adaptive.grey700 }}
+                  />
+                }
+                right={
+                  <Switch
+                    checked={isMultipleAnswer}
+                    onChange={(_, checked) => requestFormatChange(checked)}
+                  />
+                }
+                verticalPadding="large"
               />
+            </>
+          )}
+
+          <FixedBottomCTA.Double
+            leftButton={
+              <CTAButton color="dark" variant="weak" onClick={onClose}>
+                취소
+              </CTAButton>
             }
-            right={
-              <Switch
-                checked={isMultipleAnswer}
-                onChange={(_, checked) => requestFormatChange(checked)}
-              />
+            rightButton={
+              <CTAButton
+                disabled={isCompleteDisabled}
+                onClick={() => {
+                  updateQuestion(questionId, {
+                    typeId: "fivesec",
+                    title,
+                    description,
+                    imageUrl,
+                    duration,
+                    answerExample,
+                    answerType: "multiple",
+                    isMultipleAnswer,
+                    isMultiSelectEnabled,
+                    choices,
+                    minSelectCount,
+                    maxSelectCount,
+                  });
+                  onClose();
+                }}
+              >
+                완료하기
+              </CTAButton>
             }
-            verticalPadding="large"
           />
         </>
       )}
-
-      <FixedBottomCTA.Double
-        leftButton={
-          <CTAButton color="dark" variant="weak" onClick={onClose}>
-            취소
-          </CTAButton>
-        }
-        rightButton={
-          <CTAButton
-            disabled={isCompleteDisabled}
-            onClick={() => {
-              updateQuestion(questionId, {
-                typeId: "fivesec",
-                title,
-                description,
-                imageUrl,
-                duration,
-                answerExample,
-                answerType: "multiple",
-                isMultipleAnswer,
-                isMultiSelectEnabled,
-                choices,
-                minSelectCount,
-                maxSelectCount,
-              });
-              onClose();
-            }}
-          >
-            완료하기
-          </CTAButton>
-        }
-      />
-
-      <AnimatePresence>
-        {isQuestionEditorOpen && (
-          <FivesecQuestionEditorOverlay
-            key="question-editor"
-            initialTitle={title}
-            initialDescription={description}
-            onClose={() => setIsQuestionEditorOpen(false)}
-            onSave={({ title: t, description: d }) => {
-              setTitle(t);
-              setDescription(d);
-              setIsQuestionEditorOpen(false);
-            }}
-          />
-        )}
-      </AnimatePresence>
 
       <BottomSheet
         header={

--- a/src/features/question-multiple/create/MultipleCreatePage.tsx
+++ b/src/features/question-multiple/create/MultipleCreatePage.tsx
@@ -4,7 +4,6 @@ import type { MultipleChoiceItem } from "../model/types";
 import { MultipleCreateBottomCTA } from "./MultipleCreateBottomCTA";
 import { MultipleChoiceEditorOverlay } from "./MultipleChoiceEditorOverlay";
 import { MultipleCreateOptionSection } from "./MultipleCreateOptionSection";
-import { MultipleQuestionEditorOverlay } from "./MultipleQuestionEditorOverlay";
 import { useTestCreateForm } from "@/features/test-create/model/useTestCreateForm";
 import { QuestionCreateTopSection } from "@/features/test-create/ui/QuestionCreateTopSection";
 
@@ -19,31 +18,34 @@ export function MultipleCreatePage({
 }: MultipleCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
+  const existingMultiple = existing?.typeId === "multiple" ? existing : null;
 
   const [isOtherInputEnabled, setIsOtherInputEnabled] = useState(
-    existing?.typeId === "multiple" ? existing.isOtherInputEnabled : false,
+    existingMultiple?.isOtherInputEnabled ?? false,
   );
   const [isMultiSelectEnabled, setIsMultiSelectEnabled] = useState(
-    existing?.typeId === "multiple" ? existing.isMultiSelectEnabled : false,
+    existingMultiple?.isMultiSelectEnabled ?? false,
   );
-  const [isQuestionEditorOpen, setIsQuestionEditorOpen] = useState(false);
-  const [isChoiceEditorOpen, setIsChoiceEditorOpen] = useState(false);
   const [questionTitle, setQuestionTitle] = useState(
-    existing?.typeId === "multiple" ? existing.title : "",
+    existingMultiple?.title ?? "",
   );
   const [questionDescription, setQuestionDescription] = useState(
-    existing?.typeId === "multiple" ? existing.description : "",
+    existingMultiple?.description ?? "",
   );
+  const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState(
+    (existingMultiple?.title ?? "").trim().length > 0,
+  );
+  const [isChoiceEditorOpen, setIsChoiceEditorOpen] = useState(false);
   const [choices, setChoices] = useState<MultipleChoiceItem[]>(
-    existing?.typeId === "multiple" ? existing.choices : [],
+    existingMultiple?.choices ?? [],
   );
   const [draftChoices, setDraftChoices] = useState<MultipleChoiceItem[]>([]);
   const [isChoiceManageMode, setIsChoiceManageMode] = useState(false);
   const [minSelectCount, setMinSelectCount] = useState(
-    existing?.typeId === "multiple" ? existing.minSelectCount : 1,
+    existingMultiple?.minSelectCount ?? 1,
   );
   const [maxSelectCount, setMaxSelectCount] = useState(
-    existing?.typeId === "multiple" ? existing.maxSelectCount : 2,
+    existingMultiple?.maxSelectCount ?? 2,
   );
   const [editingChoiceId, setEditingChoiceId] = useState<string | null>(null);
 
@@ -92,88 +94,84 @@ export function MultipleCreatePage({
       transition={{ duration: 0.2 }}
     >
       <QuestionCreateTopSection
+        questionType="객관식"
         questionTitle={questionTitle}
         questionDescription={questionDescription}
-        onOpenQuestionEditor={() => setIsQuestionEditorOpen(true)}
-        subtitle="객관식"
+        onChangeTitle={setQuestionTitle}
+        onChangeDescription={setQuestionDescription}
+        isInputCompleted={isQuestionInputCompleted}
+        onConfirmInput={() => setIsQuestionInputCompleted(true)}
+        onClose={onClose}
       />
-      <MultipleCreateOptionSection
-        isOtherInputEnabled={isOtherInputEnabled}
-        isMultiSelectEnabled={isMultiSelectEnabled}
-        choices={visibleChoices}
-        isChoiceManageMode={isChoiceManageMode}
-        minSelectCount={minSelectCount}
-        maxSelectCount={maxSelectCount}
-        onToggleOtherInput={setIsOtherInputEnabled}
-        onToggleMultiSelect={(checked) => {
-          setIsMultiSelectEnabled(checked);
-          if (!checked) {
-            setMinSelectCount(1);
-            setMaxSelectCount(
-              Math.max(Math.min(2, Math.max(choices.length, 1)), 1),
-            );
-          }
-        }}
-        onChangeMinSelectCount={(value) => {
-          setMinSelectCount(value);
-          if (value > maxSelectCount) {
-            setMaxSelectCount(value);
-          }
-        }}
-        onChangeMaxSelectCount={(value) => {
-          setMaxSelectCount(value);
-          if (value < minSelectCount) {
-            setMinSelectCount(value);
-          }
-        }}
-        onOpenChoiceEditor={handleOpenCreateChoiceEditor}
-        onEditChoice={handleOpenEditChoiceEditor}
-        onToggleChoiceManageMode={handleToggleChoiceManageMode}
-        onDeleteChoice={(choiceId) => {
-          setActiveChoices(
-            visibleChoices.filter((choice) => choice.id !== choiceId),
-          );
-        }}
-        onReorderChoices={(nextChoices) => setActiveChoices(nextChoices)}
-        onRemoveChoiceImage={(choiceId) =>
-          setActiveChoices((prev) =>
-            prev.map((choice) =>
-              choice.id === choiceId ? { ...choice, imageUrl: "" } : choice,
-            ),
-          )
-        }
-      />
-      <MultipleCreateBottomCTA
-        isCompleteDisabled={isCompleteDisabled}
-        onCancel={onClose}
-        onComplete={() => {
-          updateQuestion(questionId, {
-            typeId: "multiple",
-            title: questionTitle,
-            description: questionDescription,
-            choices,
-            isMultiSelectEnabled,
-            isOtherInputEnabled,
-            minSelectCount,
-            maxSelectCount,
-          });
-          onClose();
-        }}
-      />
-
-      <AnimatePresence>
-        {isQuestionEditorOpen && (
-          <MultipleQuestionEditorOverlay
-            initialTitle={questionTitle}
-            initialDescription={questionDescription}
-            onClose={() => setIsQuestionEditorOpen(false)}
-            onSave={({ title, description }) => {
-              setQuestionTitle(title);
-              setQuestionDescription(description);
-              setIsQuestionEditorOpen(false);
+      {isQuestionInputCompleted && (
+        <>
+          <MultipleCreateOptionSection
+            isOtherInputEnabled={isOtherInputEnabled}
+            isMultiSelectEnabled={isMultiSelectEnabled}
+            choices={visibleChoices}
+            isChoiceManageMode={isChoiceManageMode}
+            minSelectCount={minSelectCount}
+            maxSelectCount={maxSelectCount}
+            onToggleOtherInput={setIsOtherInputEnabled}
+            onToggleMultiSelect={(checked) => {
+              setIsMultiSelectEnabled(checked);
+              if (!checked) {
+                setMinSelectCount(1);
+                setMaxSelectCount(
+                  Math.max(Math.min(2, Math.max(choices.length, 1)), 1),
+                );
+              }
+            }}
+            onChangeMinSelectCount={(value) => {
+              setMinSelectCount(value);
+              if (value > maxSelectCount) {
+                setMaxSelectCount(value);
+              }
+            }}
+            onChangeMaxSelectCount={(value) => {
+              setMaxSelectCount(value);
+              if (value < minSelectCount) {
+                setMinSelectCount(value);
+              }
+            }}
+            onOpenChoiceEditor={handleOpenCreateChoiceEditor}
+            onEditChoice={handleOpenEditChoiceEditor}
+            onToggleChoiceManageMode={handleToggleChoiceManageMode}
+            onDeleteChoice={(choiceId) => {
+              setActiveChoices(
+                visibleChoices.filter((choice) => choice.id !== choiceId),
+              );
+            }}
+            onReorderChoices={(nextChoices) => setActiveChoices(nextChoices)}
+            onRemoveChoiceImage={(choiceId) =>
+              setActiveChoices((prev) =>
+                prev.map((choice) =>
+                  choice.id === choiceId ? { ...choice, imageUrl: "" } : choice,
+                ),
+              )
+            }
+          />
+          <MultipleCreateBottomCTA
+            isCompleteDisabled={isCompleteDisabled}
+            onCancel={onClose}
+            onComplete={() => {
+              updateQuestion(questionId, {
+                typeId: "multiple",
+                title: questionTitle,
+                description: questionDescription,
+                choices,
+                isMultiSelectEnabled,
+                isOtherInputEnabled,
+                minSelectCount,
+                maxSelectCount,
+              });
+              onClose();
             }}
           />
-        )}
+        </>
+      )}
+
+      <AnimatePresence>
         {isChoiceEditorOpen && (
           <MultipleChoiceEditorOverlay
             initialChoiceName={editingChoice?.name ?? ""}

--- a/src/features/question-scale/create/ScaleCreatePage.tsx
+++ b/src/features/question-scale/create/ScaleCreatePage.tsx
@@ -1,12 +1,14 @@
 import { useState, useRef } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { Asset, Border } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { useTestCreateForm } from "@/features/test-create/model/useTestCreateForm";
+import { useQuestionImageUpload } from "@/features/test-create/model/useQuestionImageUpload";
 import { QuestionCreateTopSection } from "@/features/test-create/ui/QuestionCreateTopSection";
+import { QuestionImageUploadSection } from "@/features/test-create/ui/QuestionImageUploadSection";
+import { PhotoSelectSheet } from "@/features/test-create/ui/PhotoSelectSheet";
 import { ScaleCreateBottomCTA } from "./ScaleCreateBottomCTA";
 import { ScaleCreateOptionSection } from "./ScaleCreateOptionSection";
-import { ScaleQuestionEditorOverlay } from "./ScaleQuestionEditorOverlay";
 
 interface ScaleCreatePageProps {
   questionId: string;
@@ -18,17 +20,21 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
   const existing = questions.find((q) => q.id === questionId)?.data;
   const existingScale = existing?.typeId === "scale" ? existing : null;
 
-  const [isQuestionEditorOpen, setIsQuestionEditorOpen] = useState(false);
   const [questionTitle, setQuestionTitle] = useState(existingScale?.title ?? "");
   const [questionDescription, setQuestionDescription] = useState(existingScale?.description ?? "");
   const [questionImageUrl, setQuestionImageUrl] = useState(existingScale?.imageUrl ?? "");
+  const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState((existingScale?.title ?? "").trim().length > 0);
   const [scaleCount, setScaleCount] = useState<5 | 7>(existingScale?.scaleCount ?? 5);
   const [minLabel, setMinLabel] = useState(existingScale?.minLabel ?? "");
   const [maxLabel, setMaxLabel] = useState(existingScale?.maxLabel ?? "");
   const [isFocused, setIsFocused] = useState(false);
   const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+  const { isPhotoSheetOpen, openPhotoSheet, closePhotoSheet, handleCamera, handleAlbum } =
+    useQuestionImageUpload(setQuestionImageUrl);
+
   const isCompleteDisabled = questionTitle.trim().length === 0;
+
   const dismissKeyboard = () => {
     if (blurTimer.current) clearTimeout(blurTimer.current);
     setIsFocused(false);
@@ -36,7 +42,7 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
   };
 
   const handleContainerFocus = (e: React.FocusEvent) => {
-    if (isQuestionEditorOpen) return;
+    if (!isQuestionInputCompleted) return;
     if (e.target instanceof HTMLInputElement) {
       if (blurTimer.current) clearTimeout(blurTimer.current);
       setIsFocused(true);
@@ -44,7 +50,7 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
   };
 
   const handleContainerBlur = (e: React.FocusEvent) => {
-    if (isQuestionEditorOpen) return;
+    if (!isQuestionInputCompleted) return;
     if (e.target instanceof HTMLInputElement) {
       blurTimer.current = setTimeout(() => setIsFocused(false), 150);
     }
@@ -61,12 +67,23 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
       onBlur={handleContainerBlur}
     >
       <QuestionCreateTopSection
+        questionType="척도 평가"
         questionTitle={questionTitle}
         questionDescription={questionDescription}
-        onOpenQuestionEditor={() => setIsQuestionEditorOpen(true)}
-        subtitle="척도"
+        onChangeTitle={setQuestionTitle}
+        onChangeDescription={setQuestionDescription}
+        isInputCompleted={isQuestionInputCompleted}
+        onConfirmInput={() => setIsQuestionInputCompleted(true)}
+        onClose={onClose}
+        imageUploadSection={
+          <QuestionImageUploadSection
+            imageUrl={questionImageUrl}
+            onCameraClick={openPhotoSheet}
+            onRemove={() => setQuestionImageUrl("")}
+          />
+        }
         imageSectionContent={
-          questionImageUrl ? (
+          isQuestionInputCompleted && questionImageUrl ? (
             <>
               <div className="rounded-2xl bg-white p-4">
                 <div
@@ -80,18 +97,8 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
                   }}
                 >
                   <div className="flex h-full w-full flex-col items-end justify-between">
-                    <button
-                      type="button"
-                      onClick={() => setQuestionImageUrl("")}
-                      aria-label="이미지 삭제"
-                    >
-                      <Asset.Icon
-                        frameShape={Asset.frameShape.CircleXSmall}
-                        backgroundColor={adaptive.greyOpacity600}
-                        name="icon-sweetshop-x-white"
-                        scale={0.66}
-                        aria-hidden
-                      />
+                    <button type="button" onClick={() => setQuestionImageUrl("")} aria-label="이미지 삭제">
+                      <Asset.Icon frameShape={Asset.frameShape.CircleXSmall} backgroundColor={adaptive.greyOpacity600} name="icon-sweetshop-x-white" scale={0.66} aria-hidden />
                     </button>
                   </div>
                 </div>
@@ -103,49 +110,43 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
           )
         }
       />
-      <ScaleCreateOptionSection
-        scaleCount={scaleCount}
-        minLabel={minLabel}
-        maxLabel={maxLabel}
-        onToggleSevenPoint={(checked) => setScaleCount(checked ? 7 : 5)}
-        onChangeMinLabel={setMinLabel}
-        onChangeMaxLabel={setMaxLabel}
-      />
-      <ScaleCreateBottomCTA
-        isCompleteDisabled={isCompleteDisabled}
-        isFocused={isFocused}
-        onDismissKeyboard={dismissKeyboard}
-        onCancel={onClose}
-        onComplete={() => {
-          updateQuestion(questionId, {
-            typeId: "scale",
-            title: questionTitle,
-            description: questionDescription,
-            scaleCount,
-            minLabel,
-            maxLabel,
-            ...(questionImageUrl.trim() ? { imageUrl: questionImageUrl.trim() } : {}),
-          });
-          onClose();
-        }}
-      />
-
-      <AnimatePresence>
-        {isQuestionEditorOpen && (
-          <ScaleQuestionEditorOverlay
-            initialTitle={questionTitle}
-            initialDescription={questionDescription}
-            initialImageUrl={questionImageUrl}
-            onClose={() => setIsQuestionEditorOpen(false)}
-            onSave={({ title, description, imageUrl }) => {
-              setQuestionTitle(title);
-              setQuestionDescription(description);
-              setQuestionImageUrl(imageUrl);
-              setIsQuestionEditorOpen(false);
+      {isQuestionInputCompleted && (
+        <>
+          <ScaleCreateOptionSection
+            scaleCount={scaleCount}
+            minLabel={minLabel}
+            maxLabel={maxLabel}
+            onToggleSevenPoint={(checked) => setScaleCount(checked ? 7 : 5)}
+            onChangeMinLabel={setMinLabel}
+            onChangeMaxLabel={setMaxLabel}
+          />
+          <ScaleCreateBottomCTA
+            isCompleteDisabled={isCompleteDisabled}
+            isFocused={isFocused}
+            onDismissKeyboard={dismissKeyboard}
+            onCancel={onClose}
+            onComplete={() => {
+              updateQuestion(questionId, {
+                typeId: "scale",
+                title: questionTitle,
+                description: questionDescription,
+                scaleCount,
+                minLabel,
+                maxLabel,
+                ...(questionImageUrl.trim() ? { imageUrl: questionImageUrl.trim() } : {}),
+              });
+              onClose();
             }}
           />
-        )}
-      </AnimatePresence>
+        </>
+      )}
+
+      <PhotoSelectSheet
+        open={isPhotoSheetOpen}
+        onClose={closePhotoSheet}
+        onCamera={handleCamera}
+        onAlbum={handleAlbum}
+      />
     </motion.div>
   );
 }

--- a/src/features/question-scale/create/ScaleCreatePage.tsx
+++ b/src/features/question-scale/create/ScaleCreatePage.tsx
@@ -85,7 +85,7 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
         imageSectionContent={
           isQuestionInputCompleted && questionImageUrl ? (
             <>
-              <div className="rounded-2xl bg-white p-4">
+              <div className="rounded-2xl bg-white px-4 pb-4">
                 <div
                   className="w-full rounded-2xl p-1.5"
                   style={{

--- a/src/features/question-subjective/create/SubjectiveCreatePage.tsx
+++ b/src/features/question-subjective/create/SubjectiveCreatePage.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import { Asset, Border, TextArea } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { useTestCreateForm } from "@/features/test-create/model/useTestCreateForm";
+import { useQuestionImageUpload } from "@/features/test-create/model/useQuestionImageUpload";
 import { QuestionCreateTopSection } from "@/features/test-create/ui/QuestionCreateTopSection";
+import { QuestionImageUploadSection } from "@/features/test-create/ui/QuestionImageUploadSection";
+import { PhotoSelectSheet } from "@/features/test-create/ui/PhotoSelectSheet";
 import { SubjectiveCreateBottomCTA } from "./SubjectiveCreateBottomCTA";
-import { SubjectiveQuestionEditorOverlay } from "./SubjectiveQuestionEditorOverlay";
 
 interface SubjectiveCreatePageProps {
   questionId: string;
@@ -15,23 +17,28 @@ interface SubjectiveCreatePageProps {
 export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
+  const existingSubjective = existing?.typeId === "subjective" ? existing : null;
 
   const [questionTitle, setQuestionTitle] = useState(
-    existing?.typeId === "subjective" ? existing.title : "",
+    existingSubjective?.title ?? "",
   );
   const [questionDescription, setQuestionDescription] = useState(
-    existing?.typeId === "subjective" ? existing.description : "",
+    existingSubjective?.description ?? "",
   );
   const [questionImageUrl, setQuestionImageUrl] = useState(
-    existing?.typeId === "subjective" ? existing.imageUrl : "",
+    existingSubjective?.imageUrl ?? "",
   );
   const [placeholder] = useState(
-    existing?.typeId === "subjective" ? existing.placeholder : "",
+    existingSubjective?.placeholder ?? "",
   );
   const [maxLength] = useState<number | null>(
-    existing?.typeId === "subjective" ? existing.maxLength : null,
+    existingSubjective?.maxLength ?? null,
   );
-  const [isQuestionEditorOpen, setIsQuestionEditorOpen] = useState(false);
+  const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState(
+    (existingSubjective?.title ?? "").trim().length > 0,
+  );
+  const { isPhotoSheetOpen, openPhotoSheet, closePhotoSheet, handleCamera, handleAlbum } =
+    useQuestionImageUpload(setQuestionImageUrl);
 
   const isCompleteDisabled = questionTitle.trim().length === 0;
 
@@ -44,12 +51,23 @@ export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePa
       transition={{ duration: 0.2 }}
     >
       <QuestionCreateTopSection
+        questionType="주관식"
         questionTitle={questionTitle}
         questionDescription={questionDescription}
-        onOpenQuestionEditor={() => setIsQuestionEditorOpen(true)}
-        subtitle="주관식"
+        onChangeTitle={setQuestionTitle}
+        onChangeDescription={setQuestionDescription}
+        isInputCompleted={isQuestionInputCompleted}
+        onConfirmInput={() => setIsQuestionInputCompleted(true)}
+        onClose={onClose}
+        imageUploadSection={
+          <QuestionImageUploadSection
+            imageUrl={questionImageUrl}
+            onCameraClick={openPhotoSheet}
+            onRemove={() => setQuestionImageUrl("")}
+          />
+        }
         imageSectionContent={
-          questionImageUrl ? (
+          isQuestionInputCompleted && questionImageUrl ? (
             <>
               <div className="rounded-2xl bg-white p-4">
                 <div
@@ -87,51 +105,43 @@ export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePa
         }
       />
 
-      {/* TODO: SubjectiveCreateOptionSection */}
-      <TextArea
-        variant="box"
-        hasError={false}
-        label="답변 작성"
-        labelOption="sustain"
-        value={placeholder}
-        placeholder="예시 입력창이에요"
-        height={200}
-        readOnly
-      />
+      {isQuestionInputCompleted && (
+        <>
+          <TextArea
+            variant="box"
+            hasError={false}
+            label="답변 작성"
+            labelOption="sustain"
+            value={placeholder}
+            placeholder="예시 입력창이에요"
+            height={200}
+            readOnly
+          />
 
-      <SubjectiveCreateBottomCTA
-        isCompleteDisabled={isCompleteDisabled}
-        onCancel={onClose}
-        onComplete={() => {
-          updateQuestion(questionId, {
-            typeId: "subjective",
-            title: questionTitle,
-            description: questionDescription,
-            imageUrl: questionImageUrl,
-            placeholder,
-            maxLength,
-          });
-          onClose();
-        }}
-      />
-
-      <AnimatePresence>
-        {isQuestionEditorOpen && (
-          <SubjectiveQuestionEditorOverlay
-            key="question-editor"
-            initialTitle={questionTitle}
-            initialDescription={questionDescription}
-            initialImageUrl={questionImageUrl}
-            onClose={() => setIsQuestionEditorOpen(false)}
-            onSave={({ title, description, imageUrl }) => {
-              setQuestionTitle(title);
-              setQuestionDescription(description);
-              setQuestionImageUrl(imageUrl);
-              setIsQuestionEditorOpen(false);
+          <SubjectiveCreateBottomCTA
+            isCompleteDisabled={isCompleteDisabled}
+            onCancel={onClose}
+            onComplete={() => {
+              updateQuestion(questionId, {
+                typeId: "subjective",
+                title: questionTitle,
+                description: questionDescription,
+                imageUrl: questionImageUrl,
+                placeholder,
+                maxLength,
+              });
+              onClose();
             }}
           />
-        )}
-      </AnimatePresence>
+        </>
+      )}
+
+      <PhotoSelectSheet
+        open={isPhotoSheetOpen}
+        onClose={closePhotoSheet}
+        onCamera={handleCamera}
+        onAlbum={handleAlbum}
+      />
     </motion.div>
   );
 }

--- a/src/features/question-subjective/create/SubjectiveCreatePage.tsx
+++ b/src/features/question-subjective/create/SubjectiveCreatePage.tsx
@@ -69,7 +69,7 @@ export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePa
         imageSectionContent={
           isQuestionInputCompleted && questionImageUrl ? (
             <>
-              <div className="rounded-2xl bg-white p-4">
+              <div className="rounded-2xl bg-white px-4 pb-4">
                 <div
                   className="w-full rounded-2xl p-1.5"
                   style={{

--- a/src/features/question-tree/create/TreeCreatePage.tsx
+++ b/src/features/question-tree/create/TreeCreatePage.tsx
@@ -1,10 +1,9 @@
 import { useState } from "react";
-import { motion, AnimatePresence } from "framer-motion";
+import { motion } from "framer-motion";
 import type { TreeNodeItem } from "../model/types";
 import { TreeCreateBottomCTA } from "./TreeCreateBottomCTA";
 import { TreeCreateOptionSection } from "./TreeCreateOptionSection";
 import { TreeNodeAddSheet } from "./TreeNodeAddSheet";
-import { TreeQuestionEditorOverlay } from "./TreeQuestionEditorOverlay";
 import { useTestCreateForm } from "@/features/test-create/model/useTestCreateForm";
 import { QuestionCreateTopSection } from "@/features/test-create/ui/QuestionCreateTopSection";
 
@@ -21,19 +20,22 @@ type NodeSheetMode =
 export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
+  const existingTree = existing?.typeId === "tree" ? existing : null;
 
   const [questionTitle, setQuestionTitle] = useState(
-    existing?.typeId === "tree" ? existing.title : "",
+    existingTree?.title ?? "",
   );
   const [questionDescription, setQuestionDescription] = useState(
-    existing?.typeId === "tree" ? existing.description : "",
+    existingTree?.description ?? "",
+  );
+  const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState(
+    (existingTree?.title ?? "").trim().length > 0,
   );
   const [nodes, setNodes] = useState<TreeNodeItem[]>(
-    existing?.typeId === "tree" ? existing.nodes : [],
+    existingTree?.nodes ?? [],
   );
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [isManageMode, setIsManageMode] = useState(false);
-  const [isQuestionEditorOpen, setIsQuestionEditorOpen] = useState(false);
   const [nodeSheetMode, setNodeSheetMode] = useState<NodeSheetMode | null>(null);
 
   const isCompleteDisabled =
@@ -126,42 +128,50 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
       transition={{ duration: 0.2 }}
     >
       <QuestionCreateTopSection
+        questionType="트리 테스트"
         questionTitle={questionTitle}
         questionDescription={questionDescription}
-        onOpenQuestionEditor={() => setIsQuestionEditorOpen(true)}
-        subtitle="트리 테스트"
+        onChangeTitle={setQuestionTitle}
+        onChangeDescription={setQuestionDescription}
+        isInputCompleted={isQuestionInputCompleted}
+        onConfirmInput={() => setIsQuestionInputCompleted(true)}
+        onClose={onClose}
       />
-      <TreeCreateOptionSection
-        nodes={nodes}
-        selectedNodeId={selectedNodeId}
-        isManageMode={isManageMode}
-        onOpenNodeEditor={() => setNodeSheetMode({ kind: "create-root" })}
-        onSelectNode={setSelectedNodeId}
-        onEditNode={(nodeId) => {
-          const target = findNode(nodes, nodeId);
-          if (!target) return;
-          setNodeSheetMode({ kind: "rename", nodeId, initialName: target.name });
-        }}
-        onAddChildNode={handleAddChildNode}
-        onToggleManageMode={() => setIsManageMode((prev) => !prev)}
-        onDeleteNode={(nodeId) => {
-          setNodes((prev) => deleteNode(prev, nodeId));
-          setSelectedNodeId((prev) => (prev === nodeId ? null : prev));
-        }}
-      />
-      <TreeCreateBottomCTA
-        isCompleteDisabled={isCompleteDisabled}
-        onCancel={onClose}
-        onComplete={() => {
-          updateQuestion(questionId, {
-            typeId: "tree",
-            title: questionTitle,
-            description: questionDescription,
-            nodes,
-          });
-          onClose();
-        }}
-      />
+      {isQuestionInputCompleted && (
+        <>
+          <TreeCreateOptionSection
+            nodes={nodes}
+            selectedNodeId={selectedNodeId}
+            isManageMode={isManageMode}
+            onOpenNodeEditor={() => setNodeSheetMode({ kind: "create-root" })}
+            onSelectNode={setSelectedNodeId}
+            onEditNode={(nodeId) => {
+              const target = findNode(nodes, nodeId);
+              if (!target) return;
+              setNodeSheetMode({ kind: "rename", nodeId, initialName: target.name });
+            }}
+            onAddChildNode={handleAddChildNode}
+            onToggleManageMode={() => setIsManageMode((prev) => !prev)}
+            onDeleteNode={(nodeId) => {
+              setNodes((prev) => deleteNode(prev, nodeId));
+              setSelectedNodeId((prev) => (prev === nodeId ? null : prev));
+            }}
+          />
+          <TreeCreateBottomCTA
+            isCompleteDisabled={isCompleteDisabled}
+            onCancel={onClose}
+            onComplete={() => {
+              updateQuestion(questionId, {
+                typeId: "tree",
+                title: questionTitle,
+                description: questionDescription,
+                nodes,
+              });
+              onClose();
+            }}
+          />
+        </>
+      )}
 
       <TreeNodeAddSheet
         key={nodeSheetMode ? `${nodeSheetMode.kind}-${'nodeId' in nodeSheetMode ? nodeSheetMode.nodeId : 'root'}` : 'closed'}
@@ -171,21 +181,6 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
         onClose={() => setNodeSheetMode(null)}
         onConfirm={handleNodeSheetConfirm}
       />
-
-      <AnimatePresence>
-        {isQuestionEditorOpen && (
-          <TreeQuestionEditorOverlay
-            initialTitle={questionTitle}
-            initialDescription={questionDescription}
-            onClose={() => setIsQuestionEditorOpen(false)}
-            onSave={({ title, description }) => {
-              setQuestionTitle(title);
-              setQuestionDescription(description);
-              setIsQuestionEditorOpen(false);
-            }}
-          />
-        )}
-      </AnimatePresence>
     </motion.div>
   );
 }

--- a/src/features/test-create/model/useQuestionImageUpload.ts
+++ b/src/features/test-create/model/useQuestionImageUpload.ts
@@ -1,0 +1,47 @@
+import { useState } from "react";
+import {
+  openCamera,
+  fetchAlbumPhotos,
+  OpenCameraPermissionError,
+  FetchAlbumPhotosPermissionError,
+} from "@apps-in-toss/web-framework";
+
+export function useQuestionImageUpload(onUpload: (url: string) => void) {
+  const [isPhotoSheetOpen, setIsPhotoSheetOpen] = useState(false);
+
+  const handleCamera = async () => {
+    try {
+      const response = await openCamera({ base64: true, maxWidth: 1280 });
+      onUpload(`data:image/jpeg;base64,${response.dataUri}`);
+    } catch (error) {
+      if (error instanceof OpenCameraPermissionError) {
+        await openCamera.openPermissionDialog();
+      } else {
+        console.error("[useQuestionImageUpload handleCamera]", error);
+      }
+    }
+  };
+
+  const handleAlbum = async () => {
+    try {
+      const response = await fetchAlbumPhotos({ base64: true, maxWidth: 1280, maxCount: 1 });
+      if (response[0]) {
+        onUpload(`data:image/jpeg;base64,${response[0].dataUri}`);
+      }
+    } catch (error) {
+      if (error instanceof FetchAlbumPhotosPermissionError) {
+        await fetchAlbumPhotos.openPermissionDialog();
+      } else {
+        console.error("[useQuestionImageUpload handleAlbum]", error);
+      }
+    }
+  };
+
+  return {
+    isPhotoSheetOpen,
+    openPhotoSheet: () => setIsPhotoSheetOpen(true),
+    closePhotoSheet: () => setIsPhotoSheetOpen(false),
+    handleCamera,
+    handleAlbum,
+  };
+}

--- a/src/features/test-create/model/useQuestionImageUpload.ts
+++ b/src/features/test-create/model/useQuestionImageUpload.ts
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useToast } from "@toss/tds-mobile";
 import {
   openCamera,
   fetchAlbumPhotos,
@@ -8,6 +9,7 @@ import {
 
 export function useQuestionImageUpload(onUpload: (url: string) => void) {
   const [isPhotoSheetOpen, setIsPhotoSheetOpen] = useState(false);
+  const { openToast } = useToast();
 
   const handleCamera = async () => {
     try {
@@ -17,7 +19,7 @@ export function useQuestionImageUpload(onUpload: (url: string) => void) {
       if (error instanceof OpenCameraPermissionError) {
         await openCamera.openPermissionDialog();
       } else {
-        console.error("[useQuestionImageUpload handleCamera]", error);
+        openToast("이미지를 불러오는 중 오류가 발생했어요.", { type: "bottom" });
       }
     }
   };
@@ -32,7 +34,7 @@ export function useQuestionImageUpload(onUpload: (url: string) => void) {
       if (error instanceof FetchAlbumPhotosPermissionError) {
         await fetchAlbumPhotos.openPermissionDialog();
       } else {
-        console.error("[useQuestionImageUpload handleAlbum]", error);
+        openToast("이미지를 불러오는 중 오류가 발생했어요.", { type: "bottom" });
       }
     }
   };

--- a/src/features/test-create/ui/QuestionCreateTopSection.tsx
+++ b/src/features/test-create/ui/QuestionCreateTopSection.tsx
@@ -1,58 +1,335 @@
-import type { ReactNode } from "react";
-import { Border, Top } from "@toss/tds-mobile";
+import { useState, useEffect, useRef, type ReactNode } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Asset, Border, CTAButton, FixedBottomCTA, List, ListHeader, ListRow, TextField } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
+import { QuestionEditSheet, type EditSheetConfig } from "./QuestionEditSheet";
+
+// ── Hooks ──────────────────────────────────────────────────
+
+function useFocusState() {
+  const [isFocused, setIsFocused] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return {
+    isFocused,
+    onFocus: () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setIsFocused(true);
+    },
+    onBlur: () => {
+      timerRef.current = setTimeout(() => setIsFocused(false), 100);
+    },
+    blur: () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setIsFocused(false);
+      (document.activeElement as HTMLElement)?.blur();
+    },
+  };
+}
+
+type EditingField = "title" | "description";
+
+function useEditSheet(questionType: string, titlePlaceholder: string) {
+  const [editingField, setEditingField] = useState<EditingField | null>(null);
+  const [draft, setDraft] = useState("");
+  const [fieldVisible, setFieldVisible] = useState(false);
+  const draftRef = useRef("");
+
+  useEffect(() => {
+    if (editingField === null) return;
+    const t1 = setTimeout(() => setDraft(draftRef.current), 0);
+    const t2 = setTimeout(() => setFieldVisible(true), 4);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      setFieldVisible(false);
+    };
+  }, [editingField]);
+
+  const config: EditSheetConfig =
+    editingField === "title"
+      ? {
+          header: "어떻게 질문할까요?",
+          label: `${questionType} 질문`,
+          fieldPlaceholder: titlePlaceholder,
+          maxLength: 34,
+        }
+      : {
+          header: "(선택) 질문에 대한 추가 설명을 할까요?",
+          label: "추가 설명",
+          fieldPlaceholder: "추가 설명을 입력해주세요",
+          maxLength: 55,
+        };
+
+  return {
+    editingField,
+    draft,
+    fieldVisible,
+    config,
+    confirmDisabled: editingField === "title" && draft.trim().length === 0,
+    open: (field: EditingField, initialValue: string) => {
+      draftRef.current = initialValue;
+      setDraft(initialValue);
+      setEditingField(field);
+    },
+    close: () => {
+      setEditingField(null);
+      setDraft("");
+    },
+    setDraft,
+  };
+}
+
+// ── Sub-components ─────────────────────────────────────────
+
+interface ClickableTopRowProps {
+  label: string;
+  text: string;
+  placeholder: string;
+  onClick: () => void;
+}
+
+function ClickableTopRow({ label, text, placeholder, onClick }: ClickableTopRowProps) {
+  const hasText = text.trim().length > 0;
+  return (
+    <ListRow
+      onClick={onClick}
+      contents={
+        <ListRow.Texts
+          type="2RowTypeD"
+          top={label}
+          topProps={{ color: adaptive.grey600 }}
+          bottom={hasText ? text : placeholder}
+          bottomProps={{
+            color: hasText ? adaptive.grey800 : adaptive.grey400,
+            fontWeight: "bold",
+          }}
+        />
+      }
+      right={<Asset.Icon name="icon-pencil-18px-mono" color={adaptive.grey400} />}
+      verticalPadding="large"
+    />
+  );
+}
+
+// ── Main component ─────────────────────────────────────────
 
 interface QuestionCreateTopSectionProps {
+  questionType: string;
   questionTitle: string;
   questionDescription: string;
-  onOpenQuestionEditor: () => void;
-  subtitle: string;
+  onChangeTitle: (title: string) => void;
+  onChangeDescription: (description: string) => void;
+  isInputCompleted: boolean;
+  onConfirmInput: () => void;
+  onClose: () => void;
+  titlePlaceholder?: string;
   imageSectionContent?: ReactNode;
+  imageUploadSection?: ReactNode;
 }
 
 export function QuestionCreateTopSection({
+  questionType,
   questionTitle,
   questionDescription,
-  onOpenQuestionEditor,
-  subtitle,
+  onChangeTitle,
+  onChangeDescription,
+  isInputCompleted,
+  onConfirmInput,
+  onClose,
+  titlePlaceholder,
   imageSectionContent,
+  imageUploadSection,
 }: QuestionCreateTopSectionProps) {
-  const hasQuestionTitle = questionTitle.trim().length > 0;
-  const displayTitle = hasQuestionTitle ? questionTitle : "제목이 없어요";
-  const displayDescription =
-    questionDescription.trim().length > 0 ? questionDescription : "설명이 없어요";
+  const placeholder = titlePlaceholder ?? `${questionType} 질문을 입력해주세요`;
 
+  const [phase, setPhase] = useState<"title" | "detail">(questionTitle.trim().length > 0 ? "detail" : "title");
+  const [isEditing, setIsEditing] = useState(false);
+
+  const titleFocus = useFocusState();
+  const descFocus = useFocusState();
+  const sheet = useEditSheet(questionType, placeholder);
+
+  useEffect(() => {
+    if (!isInputCompleted && phase === "title" && !titleFocus.isFocused && questionTitle.trim().length > 0) {
+      const timer = setTimeout(() => setPhase("detail"), 150);
+      return () => clearTimeout(timer);
+    }
+  }, [isInputCompleted, phase, titleFocus.isFocused, questionTitle]);
+
+  const handleConfirmTitle = () => {
+    titleFocus.blur();
+    if (questionTitle.trim().length > 0) setPhase("detail");
+  };
+
+  const handleConfirmSheet = () => {
+    const trimmed = sheet.draft.trim();
+    if (sheet.editingField === "title" && trimmed) onChangeTitle(trimmed);
+    else if (sheet.editingField === "description") onChangeDescription(trimmed);
+    sheet.close();
+  };
+
+  const editSheet = (
+    <QuestionEditSheet
+      open={sheet.editingField !== null}
+      draft={sheet.draft}
+      fieldVisible={sheet.fieldVisible}
+      config={sheet.config}
+      confirmDisabled={sheet.confirmDisabled}
+      onClose={sheet.close}
+      onConfirm={handleConfirmSheet}
+      onDraftChange={sheet.setDraft}
+    />
+  );
+
+  // ── Completed + Editing mode ──
+  if (isInputCompleted && isEditing) {
+    return (
+      <div className="fixed inset-0 z-[60] overflow-y-auto bg-white pb-28">
+        <ClickableTopRow label={`${questionType} 질문`} text={questionTitle} placeholder={placeholder} onClick={() => sheet.open("title", questionTitle)} />
+        <ClickableTopRow label="(선택) 추가 설명" text={questionDescription} placeholder="추가 설명을 입력해주세요" onClick={() => sheet.open("description", questionDescription)} />
+        {imageUploadSection}
+        <FixedBottomCTA.Double
+          leftButton={
+            <CTAButton color="dark" variant="weak" onClick={() => setIsEditing(false)}>
+              닫기
+            </CTAButton>
+          }
+          rightButton={<CTAButton onClick={() => setIsEditing(false)}>입력 완료</CTAButton>}
+        />
+        {editSheet}
+      </div>
+    );
+  }
+
+  // ── Completed read-only mode ──
+  if (isInputCompleted) {
+    const hasDescription = questionDescription.trim().length > 0;
+    return (
+      <>
+        <List>
+          <ListHeader
+            descriptionPosition="bottom"
+            rightAlignment="center"
+            titleWidthRatio={0.6}
+            title={
+              <ListHeader.TitleParagraph typography="t5" fontWeight="medium" color={adaptive.grey600}>
+                {questionType}
+              </ListHeader.TitleParagraph>
+            }
+          />
+          <ListRow
+            contents={
+              hasDescription ? (
+                <ListRow.Texts type="2RowTypeC" top={questionTitle} topProps={{ color: adaptive.grey800, fontWeight: "bold" }} bottom={questionDescription} bottomProps={{ color: adaptive.grey500 }} />
+              ) : (
+                <ListRow.Texts type="1RowTypeA" top={questionTitle} topProps={{ color: adaptive.grey800, fontWeight: "bold" }} />
+              )
+            }
+            right={
+              <button type="button" onClick={() => setIsEditing(true)}>
+                <Asset.Icon name="icon-pencil-18px-mono" color={adaptive.grey400} />
+              </button>
+            }
+            verticalPadding="small"
+          />
+        </List>
+        {imageSectionContent ?? <Border variant="height16" />}
+      </>
+    );
+  }
+
+  // ── Title input phase ──
+  if (phase === "title") {
+    return (
+      <>
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
+          <TextField.Clearable
+            variant="line"
+            label="어떻게 질문할까요?"
+            labelOption="sustain"
+            value={questionTitle}
+            placeholder={placeholder}
+            maxLength={34}
+            autoFocus
+            onChange={(e) => onChangeTitle(e.target.value.slice(0, 34))}
+            onClear={() => onChangeTitle("")}
+            onFocus={titleFocus.onFocus}
+            onBlur={titleFocus.onBlur}
+          />
+        </motion.div>
+        <AnimatePresence mode="wait">
+          {titleFocus.isFocused ? (
+            <motion.div key="confirm-title" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
+              <FixedBottomCTA fixedAboveKeyboard onClick={handleConfirmTitle}>
+                확인
+              </FixedBottomCTA>
+            </motion.div>
+          ) : (
+            <motion.div key="input-complete" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
+              <FixedBottomCTA.Double
+                leftButton={
+                  <CTAButton color="dark" variant="weak" onClick={onClose}>
+                    닫기
+                  </CTAButton>
+                }
+                rightButton={
+                  <CTAButton disabled={questionTitle.trim().length === 0} onClick={onConfirmInput}>
+                    입력 완료
+                  </CTAButton>
+                }
+              />
+            </motion.div>
+          )}
+        </AnimatePresence>
+      </>
+    );
+  }
+
+  // ── Detail input phase ──
   return (
     <>
-      <Top
-        title={
-          <Top.TitleParagraph size={22} color={adaptive.grey900}>
-            {displayTitle}
-          </Top.TitleParagraph>
-        }
-        subtitleTop={
-          <Top.SubtitleParagraph size={15} color={adaptive.grey500}>
-            {subtitle}
-          </Top.SubtitleParagraph>
-        }
-        subtitleBottom={
-          <Top.SubtitleParagraph size={15}>
-            {displayDescription}
-          </Top.SubtitleParagraph>
-        }
-        lower={
-          <Top.LowerButton
-            color={hasQuestionTitle ? "dark" : "primary"}
-            size="small"
-            variant={hasQuestionTitle ? "weak" : "fill"}
-            display="inline"
-            onClick={onOpenQuestionEditor}
-          >
-            {hasQuestionTitle ? "수정하기" : "입력하기"}
-          </Top.LowerButton>
-        }
-      />
-      {imageSectionContent ?? <Border variant="height16" className="shrink-0" />}
+      <ClickableTopRow label={`${questionType} 질문`} text={questionTitle} placeholder={placeholder} onClick={() => sheet.open("title", questionTitle)} />
+      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
+        <TextField.Clearable
+          variant="line"
+          label="(선택) 추가 설명을 할까요?"
+          labelOption="sustain"
+          value={questionDescription}
+          placeholder="추가 설명을 입력해주세요"
+          maxLength={55}
+          onChange={(e) => onChangeDescription(e.target.value.slice(0, 55))}
+          onClear={() => onChangeDescription("")}
+          onFocus={descFocus.onFocus}
+          onBlur={descFocus.onBlur}
+        />
+      </motion.div>
+      {imageUploadSection}
+      <AnimatePresence mode="wait">
+        {descFocus.isFocused ? (
+          <motion.div key="confirm-description" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
+            <FixedBottomCTA fixedAboveKeyboard onClick={descFocus.blur}>
+              확인
+            </FixedBottomCTA>
+          </motion.div>
+        ) : (
+          <motion.div key="input-complete" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
+            <FixedBottomCTA.Double
+              leftButton={
+                <CTAButton color="dark" variant="weak" onClick={onClose}>
+                  닫기
+                </CTAButton>
+              }
+              rightButton={
+                <CTAButton disabled={questionTitle.trim().length === 0} onClick={onConfirmInput}>
+                  입력 완료
+                </CTAButton>
+              }
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+      {editSheet}
     </>
   );
 }

--- a/src/features/test-create/ui/QuestionCreateTopSection.tsx
+++ b/src/features/test-create/ui/QuestionCreateTopSection.tsx
@@ -1,83 +1,9 @@
-import { useState, useEffect, useRef, type ReactNode } from "react";
+import { useState, useEffect, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Asset, Border, CTAButton, FixedBottomCTA, List, ListHeader, ListRow, Spacing, TextField } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
-import { QuestionEditSheet, type EditSheetConfig } from "./QuestionEditSheet";
-
-// ── Hooks ──────────────────────────────────────────────────
-
-function useFocusState() {
-  const [isFocused, setIsFocused] = useState(false);
-  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  return {
-    isFocused,
-    onFocus: () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      setIsFocused(true);
-    },
-    onBlur: () => {
-      timerRef.current = setTimeout(() => setIsFocused(false), 100);
-    },
-    blur: () => {
-      if (timerRef.current) clearTimeout(timerRef.current);
-      setIsFocused(false);
-      (document.activeElement as HTMLElement)?.blur();
-    },
-  };
-}
-
-type EditingField = "title" | "description";
-
-function useEditSheet(questionType: string, titlePlaceholder: string) {
-  const [editingField, setEditingField] = useState<EditingField | null>(null);
-  const [draft, setDraft] = useState("");
-  const [fieldVisible, setFieldVisible] = useState(false);
-  const draftRef = useRef("");
-
-  useEffect(() => {
-    if (editingField === null) return;
-    setDraft(draftRef.current);
-    const t = setTimeout(() => setFieldVisible(true), 4);
-    return () => {
-      clearTimeout(t);
-      setFieldVisible(false);
-    };
-  }, [editingField]);
-
-  const config: EditSheetConfig =
-    editingField === "title"
-      ? {
-        header: "어떻게 질문할까요?",
-        label: `${questionType} 질문`,
-        fieldPlaceholder: titlePlaceholder,
-        maxLength: 34,
-      }
-      : {
-        header: "(선택) 질문에 대한 추가 설명을 할까요?",
-        label: "추가 설명",
-        fieldPlaceholder: "추가 설명을 입력해주세요",
-        maxLength: 55,
-      };
-
-  return {
-    editingField,
-    draft,
-    fieldVisible,
-    config,
-    confirmDisabled: editingField === "title" && draft.trim().length === 0,
-    open: (field: EditingField, initialValue: string) => {
-      draftRef.current = initialValue;
-      setDraft(initialValue);
-      setEditingField(field);
-    },
-    close: () => {
-      setEditingField(null);
-      setDraft("");
-    },
-    setDraft,
-  };
-}
+import { QuestionEditSheet } from "./QuestionEditSheet";
+import { useFocusState, useEditSheet } from "./useQuestionCreateTopSectionHooks";
 
 // ── Sub-components ─────────────────────────────────────────
 
@@ -108,6 +34,51 @@ function ClickableTopRow({ label, text, placeholder, onClick }: ClickableTopRowP
       right={<Asset.Icon name="icon-pencil-18px-mono" color={adaptive.grey400} />}
       verticalPadding="large"
     />
+  );
+}
+
+interface PhaseBottomCTAProps {
+  isFocused: boolean;
+  focusConfirmKey: string;
+  onFocusConfirm: () => void;
+  onClose: () => void;
+  onInputComplete: () => void;
+  isInputCompleteDisabled: boolean;
+}
+
+function PhaseBottomCTA({
+  isFocused,
+  focusConfirmKey,
+  onFocusConfirm,
+  onClose,
+  onInputComplete,
+  isInputCompleteDisabled,
+}: PhaseBottomCTAProps) {
+  return (
+    <AnimatePresence mode="wait">
+      {isFocused ? (
+        <motion.div key={focusConfirmKey} initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
+          <FixedBottomCTA fixedAboveKeyboard onClick={onFocusConfirm}>
+            확인
+          </FixedBottomCTA>
+        </motion.div>
+      ) : (
+        <motion.div key="input-complete" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
+          <FixedBottomCTA.Double
+            leftButton={
+              <CTAButton color="dark" variant="weak" onClick={onClose}>
+                닫기
+              </CTAButton>
+            }
+            rightButton={
+              <CTAButton disabled={isInputCompleteDisabled} onClick={onInputComplete}>
+                입력 완료
+              </CTAButton>
+            }
+          />
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }
 
@@ -181,28 +152,27 @@ export function QuestionCreateTopSection({
     />
   );
 
-  // ── Completed + Editing mode ──
-  if (isInputCompleted && isEditing) {
-    return (
-      <div className="fixed inset-0 z-[60] overflow-y-auto bg-white pb-28">
-        <ClickableTopRow label={`${questionType} 질문`} text={questionTitle} placeholder={placeholder} onClick={() => sheet.open("title", questionTitle)} />
-        <ClickableTopRow label="(선택) 추가 설명" text={questionDescription} placeholder="추가 설명을 입력해주세요" onClick={() => sheet.open("description", questionDescription)} />
-        {imageUploadSection}
-        <FixedBottomCTA.Double
-          leftButton={
-            <CTAButton color="dark" variant="weak" onClick={() => setIsEditing(false)}>
-              닫기
-            </CTAButton>
-          }
-          rightButton={<CTAButton onClick={() => setIsEditing(false)}>입력 완료</CTAButton>}
-        />
-        {editSheet}
-      </div>
-    );
-  }
-
-  // ── Completed read-only mode ──
+  // ── Completed Mode ──
   if (isInputCompleted) {
+    if (isEditing) {
+      return (
+        <div className="fixed inset-0 z-[60] overflow-y-auto bg-white pb-28">
+          <ClickableTopRow label={`${questionType} 질문`} text={questionTitle} placeholder={placeholder} onClick={() => sheet.open("title", questionTitle)} />
+          <ClickableTopRow label="(선택) 추가 설명" text={questionDescription} placeholder="추가 설명을 입력해주세요" onClick={() => sheet.open("description", questionDescription)} />
+          {imageUploadSection}
+          <FixedBottomCTA.Double
+            leftButton={
+              <CTAButton color="dark" variant="weak" onClick={() => setIsEditing(false)}>
+                닫기
+              </CTAButton>
+            }
+            rightButton={<CTAButton onClick={() => setIsEditing(false)}>입력 완료</CTAButton>}
+          />
+          {editSheet}
+        </div>
+      );
+    }
+
     const hasDescription = questionDescription.trim().length > 0;
     return (
       <>
@@ -218,6 +188,7 @@ export function QuestionCreateTopSection({
             }
           />
           <ListRow
+            style={{ paddingBottom: 16 }}
             contents={
               hasDescription ? (
                 <ListRow.Texts type="2RowTypeC" top={questionTitle} topProps={{ color: adaptive.grey800, fontWeight: "bold" }} bottom={questionDescription} bottomProps={{ color: adaptive.grey500 }} />
@@ -230,106 +201,74 @@ export function QuestionCreateTopSection({
                 <Asset.Icon name="icon-pencil-18px-mono" color={adaptive.grey400} />
               </button>
             }
-            verticalPadding="small"
           />
+          {imageSectionContent ?? <Border variant="height16" />}
         </List>
-        {imageSectionContent ?? <Border variant="height16" />}
       </>
     );
   }
 
-  // ── Title input phase ──
-  if (phase === "title") {
-    return (
-      <>
-        <Spacing size={12} />
-        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
-          <TextField.Clearable
-            variant="line"
-            label="어떻게 질문할까요?"
-            labelOption="sustain"
-            value={questionTitle}
-            placeholder={placeholder}
-            maxLength={34}
-            autoFocus
-            onChange={(e) => onChangeTitle(e.target.value.slice(0, 34))}
-            onClear={() => onChangeTitle("")}
-            onFocus={titleFocus.onFocus}
-            onBlur={titleFocus.onBlur}
-          />
-        </motion.div>
-        <AnimatePresence mode="wait">
-          {titleFocus.isFocused ? (
-            <motion.div key="confirm-title" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
-              <FixedBottomCTA fixedAboveKeyboard onClick={handleConfirmTitle}>
-                확인
-              </FixedBottomCTA>
-            </motion.div>
-          ) : (
-            <motion.div key="input-complete" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
-              <FixedBottomCTA.Double
-                leftButton={
-                  <CTAButton color="dark" variant="weak" onClick={onClose}>
-                    닫기
-                  </CTAButton>
-                }
-                rightButton={
-                  <CTAButton disabled={questionTitle.trim().length === 0} onClick={onConfirmInput}>
-                    입력 완료
-                  </CTAButton>
-                }
-              />
-            </motion.div>
-          )}
-        </AnimatePresence>
-      </>
-    );
-  }
+  // ── Input Phase ──
+  const isCompleteDisabled = questionTitle.trim().length === 0;
 
-  // ── Detail input phase ──
   return (
     <>
-      <ClickableTopRow label={`${questionType} 질문`} text={questionTitle} placeholder={placeholder} onClick={() => sheet.open("title", questionTitle)} />
-      <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
-        <TextField.Clearable
-          variant="line"
-          label="(선택) 추가 설명을 할까요?"
-          labelOption="sustain"
-          value={questionDescription}
-          placeholder="추가 설명을 입력해주세요"
-          maxLength={55}
-          onChange={(e) => onChangeDescription(e.target.value.slice(0, 55))}
-          onClear={() => onChangeDescription("")}
-          onFocus={descFocus.onFocus}
-          onBlur={descFocus.onBlur}
-        />
-      </motion.div>
-      {imageUploadSection}
-      <AnimatePresence mode="wait">
-        {descFocus.isFocused ? (
-          <motion.div key="confirm-description" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
-            <FixedBottomCTA fixedAboveKeyboard onClick={descFocus.blur}>
-              확인
-            </FixedBottomCTA>
-          </motion.div>
-        ) : (
-          <motion.div key="input-complete" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.1 }}>
-            <FixedBottomCTA.Double
-              leftButton={
-                <CTAButton color="dark" variant="weak" onClick={onClose}>
-                  닫기
-                </CTAButton>
-              }
-              rightButton={
-                <CTAButton disabled={questionTitle.trim().length === 0} onClick={onConfirmInput}>
-                  입력 완료
-                </CTAButton>
-              }
+      {phase === "title" ? (
+        <>
+          <Spacing size={12} />
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
+            <TextField.Clearable
+              variant="line"
+              label="어떻게 질문할까요?"
+              labelOption="sustain"
+              value={questionTitle}
+              placeholder={placeholder}
+              maxLength={34}
+              autoFocus
+              onChange={(e) => onChangeTitle(e.target.value.slice(0, 34))}
+              onClear={() => onChangeTitle("")}
+              onFocus={titleFocus.onFocus}
+              onBlur={titleFocus.onBlur}
             />
           </motion.div>
-        )}
-      </AnimatePresence>
-      {editSheet}
+          <PhaseBottomCTA
+            isFocused={titleFocus.isFocused}
+            focusConfirmKey="confirm-title"
+            onFocusConfirm={handleConfirmTitle}
+            onClose={onClose}
+            onInputComplete={onConfirmInput}
+            isInputCompleteDisabled={isCompleteDisabled}
+          />
+        </>
+      ) : (
+        <>
+          <ClickableTopRow label={`${questionType} 질문`} text={questionTitle} placeholder={placeholder} onClick={() => sheet.open("title", questionTitle)} />
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
+            <TextField.Clearable
+              variant="line"
+              label="(선택) 추가 설명을 할까요?"
+              labelOption="sustain"
+              value={questionDescription}
+              placeholder="추가 설명을 입력해주세요"
+              maxLength={55}
+              onChange={(e) => onChangeDescription(e.target.value.slice(0, 55))}
+              onClear={() => onChangeDescription("")}
+              onFocus={descFocus.onFocus}
+              onBlur={descFocus.onBlur}
+            />
+          </motion.div>
+          {imageUploadSection}
+          <PhaseBottomCTA
+            isFocused={descFocus.isFocused}
+            focusConfirmKey="confirm-description"
+            onFocusConfirm={descFocus.blur}
+            onClose={onClose}
+            onInputComplete={onConfirmInput}
+            isInputCompleteDisabled={isCompleteDisabled}
+          />
+          {editSheet}
+        </>
+      )}
     </>
   );
 }

--- a/src/features/test-create/ui/QuestionCreateTopSection.tsx
+++ b/src/features/test-create/ui/QuestionCreateTopSection.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, type ReactNode } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Asset, Border, CTAButton, FixedBottomCTA, List, ListHeader, ListRow, TextField } from "@toss/tds-mobile";
+import { Asset, Border, CTAButton, FixedBottomCTA, List, ListHeader, ListRow, Spacing, TextField } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { QuestionEditSheet, type EditSheetConfig } from "./QuestionEditSheet";
 
@@ -48,17 +48,17 @@ function useEditSheet(questionType: string, titlePlaceholder: string) {
   const config: EditSheetConfig =
     editingField === "title"
       ? {
-          header: "어떻게 질문할까요?",
-          label: `${questionType} 질문`,
-          fieldPlaceholder: titlePlaceholder,
-          maxLength: 34,
-        }
+        header: "어떻게 질문할까요?",
+        label: `${questionType} 질문`,
+        fieldPlaceholder: titlePlaceholder,
+        maxLength: 34,
+      }
       : {
-          header: "(선택) 질문에 대한 추가 설명을 할까요?",
-          label: "추가 설명",
-          fieldPlaceholder: "추가 설명을 입력해주세요",
-          maxLength: 55,
-        };
+        header: "(선택) 질문에 대한 추가 설명을 할까요?",
+        label: "추가 설명",
+        fieldPlaceholder: "추가 설명을 입력해주세요",
+        maxLength: 55,
+      };
 
   return {
     editingField,
@@ -242,6 +242,7 @@ export function QuestionCreateTopSection({
   if (phase === "title") {
     return (
       <>
+        <Spacing size={12} />
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
           <TextField.Clearable
             variant="line"

--- a/src/features/test-create/ui/QuestionCreateTopSection.tsx
+++ b/src/features/test-create/ui/QuestionCreateTopSection.tsx
@@ -37,11 +37,10 @@ function useEditSheet(questionType: string, titlePlaceholder: string) {
 
   useEffect(() => {
     if (editingField === null) return;
-    const t1 = setTimeout(() => setDraft(draftRef.current), 0);
-    const t2 = setTimeout(() => setFieldVisible(true), 4);
+    setDraft(draftRef.current);
+    const t = setTimeout(() => setFieldVisible(true), 4);
     return () => {
-      clearTimeout(t1);
-      clearTimeout(t2);
+      clearTimeout(t);
       setFieldVisible(false);
     };
   }, [editingField]);

--- a/src/features/test-create/ui/QuestionEditSheet.tsx
+++ b/src/features/test-create/ui/QuestionEditSheet.tsx
@@ -1,3 +1,4 @@
+import { motion } from "framer-motion";
 import { BottomSheet, TextField } from "@toss/tds-mobile";
 
 export interface EditSheetConfig {
@@ -29,39 +30,26 @@ export function QuestionEditSheet({
   onDraftChange,
 }: QuestionEditSheetProps) {
   return (
-    <>
-      {open && (
-        <style>{`
-          :has(> [aria-modal="true"]),
-          [aria-modal="true"] {
-            transition: bottom 0.25s cubic-bezier(0.4, 0, 0.2, 1), transform 0.25s cubic-bezier(0.4, 0, 0.2, 1) !important;
-          }
-        `}</style>
-      )}
-      <BottomSheet
-        header={<BottomSheet.Header>{config.header}</BottomSheet.Header>}
-        open={open}
-        onClose={onClose}
-        hasTextField
-        cta={
-          <BottomSheet.CTA
-            color="primary"
-            variant="fill"
-            disabled={confirmDisabled}
-            fixedAboveKeyboard
-            onClick={onConfirm}
-          >
-            확인
-          </BottomSheet.CTA>
-        }
-        ctaContentGap={0}
-      >
-        <div
-          style={{
-            opacity: fieldVisible ? 1 : 0,
-            transition: fieldVisible ? "opacity 0.15s ease-in" : "none",
-          }}
+    <BottomSheet
+      header={<BottomSheet.Header>{config.header}</BottomSheet.Header>}
+      open={open}
+      onClose={onClose}
+      hasTextField
+      cta={
+        <BottomSheet.CTA
+          color="primary"
+          variant="fill"
+          disabled={confirmDisabled}
+          fixedAboveKeyboard
+          onClick={onConfirm}
         >
+          확인
+        </BottomSheet.CTA>
+      }
+      ctaContentGap={0}
+    >
+      {fieldVisible && (
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
           <TextField.Clearable
             variant="line"
             hasError={false}
@@ -74,8 +62,8 @@ export function QuestionEditSheet({
             onChange={(e) => onDraftChange(e.target.value.slice(0, config.maxLength))}
             onClear={() => onDraftChange("")}
           />
-        </div>
-      </BottomSheet>
-    </>
+        </motion.div>
+      )}
+    </BottomSheet>
   );
 }

--- a/src/features/test-create/ui/QuestionEditSheet.tsx
+++ b/src/features/test-create/ui/QuestionEditSheet.tsx
@@ -1,0 +1,81 @@
+import { BottomSheet, TextField } from "@toss/tds-mobile";
+
+export interface EditSheetConfig {
+  header: string;
+  label: string;
+  fieldPlaceholder: string;
+  maxLength: number;
+}
+
+interface QuestionEditSheetProps {
+  open: boolean;
+  draft: string;
+  fieldVisible: boolean;
+  config: EditSheetConfig;
+  confirmDisabled: boolean;
+  onClose: () => void;
+  onConfirm: () => void;
+  onDraftChange: (value: string) => void;
+}
+
+export function QuestionEditSheet({
+  open,
+  draft,
+  fieldVisible,
+  config,
+  confirmDisabled,
+  onClose,
+  onConfirm,
+  onDraftChange,
+}: QuestionEditSheetProps) {
+  return (
+    <>
+      {open && (
+        <style>{`
+          :has(> [aria-modal="true"]),
+          [aria-modal="true"] {
+            transition: bottom 0.25s cubic-bezier(0.4, 0, 0.2, 1), transform 0.25s cubic-bezier(0.4, 0, 0.2, 1) !important;
+          }
+        `}</style>
+      )}
+      <BottomSheet
+        header={<BottomSheet.Header>{config.header}</BottomSheet.Header>}
+        open={open}
+        onClose={onClose}
+        hasTextField
+        cta={
+          <BottomSheet.CTA
+            color="primary"
+            variant="fill"
+            disabled={confirmDisabled}
+            fixedAboveKeyboard
+            onClick={onConfirm}
+          >
+            확인
+          </BottomSheet.CTA>
+        }
+        ctaContentGap={0}
+      >
+        <div
+          style={{
+            opacity: fieldVisible ? 1 : 0,
+            transition: fieldVisible ? "opacity 0.15s ease-in" : "none",
+          }}
+        >
+          <TextField.Clearable
+            variant="line"
+            hasError={false}
+            label={config.label}
+            labelOption="sustain"
+            value={draft}
+            placeholder={config.fieldPlaceholder}
+            maxLength={config.maxLength}
+            autoFocus
+            onChange={(e) => onDraftChange(e.target.value.slice(0, config.maxLength))}
+            onClear={() => onDraftChange("")}
+          />
+        </div>
+      </BottomSheet>
+    </>
+  );
+}

--- a/src/features/test-create/ui/QuestionImageUploadSection.tsx
+++ b/src/features/test-create/ui/QuestionImageUploadSection.tsx
@@ -1,0 +1,117 @@
+import { Asset, ListHeader, Text } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+
+interface QuestionImageUploadSectionProps {
+  imageUrl: string;
+  onCameraClick: () => void;
+  onRemove: () => void;
+}
+
+export function QuestionImageUploadSection({ imageUrl, onCameraClick, onRemove }: QuestionImageUploadSectionProps) {
+  const imageCount = imageUrl ? 1 : 0;
+
+  return (
+    <>
+      <ListHeader
+        descriptionPosition="bottom"
+        rightAlignment="center"
+        titleWidthRatio={0.6}
+        title={
+          <ListHeader.TitleParagraph typography="t5" fontWeight="medium" color={adaptive.grey800}>
+            이미지
+          </ListHeader.TitleParagraph>
+        }
+        right={
+          <ListHeader.RightText typography="t7" fontWeight="medium" color={adaptive.grey700}>
+            (선택)
+          </ListHeader.RightText>
+        }
+      />
+      <div className="flex flex-nowrap gap-2 px-5 pb-3">
+        <button
+          type="button"
+          style={{
+            width: 88,
+            height: 88,
+            backgroundColor: "var(--token-tds-color-grey-100, var(--adaptiveGrey100, #f2f4f6))",
+            borderRadius: 16,
+            padding: 16,
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 4,
+            flexShrink: 0,
+          }}
+          onClick={onCameraClick}
+        >
+          <Asset.Icon
+            frameShape={Asset.frameShape.CleanW24}
+            backgroundColor="transparent"
+            name="icon-camera-mono"
+            color={adaptive.grey600}
+            aria-hidden
+            ratio="1/1"
+          />
+          <div style={{ display: "flex" }}>
+            <Text color={adaptive.grey500} typography="t7" fontWeight="medium">
+              {imageCount}
+            </Text>
+            <Text color={adaptive.grey500} typography="t7" fontWeight="medium">
+              /1
+            </Text>
+          </div>
+        </button>
+        {imageUrl && (
+          <div
+            style={{
+              position: "relative",
+              width: 88,
+              height: 88,
+              flexShrink: 0,
+              borderRadius: 16,
+              overflow: "hidden",
+            }}
+          >
+            <img src={imageUrl} alt="질문 이미지" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
+            <div
+              style={{
+                position: "absolute",
+                top: 6,
+                left: 6,
+                right: 6,
+                bottom: 6,
+                display: "flex",
+                justifyContent: "flex-end",
+                alignItems: "flex-start",
+                pointerEvents: "none",
+              }}
+            >
+              <button
+                type="button"
+                onClick={onRemove}
+                style={{
+                  display: "flex",
+                  background: "none",
+                  border: "none",
+                  padding: 0,
+                  cursor: "pointer",
+                  pointerEvents: "auto",
+                }}
+                aria-label="이미지 삭제"
+              >
+                <Asset.Icon
+                  frameShape={Asset.frameShape.CircleXSmall}
+                  backgroundColor={adaptive.greyOpacity600}
+                  name="icon-sweetshop-x-white"
+                  scale={0.66}
+                  aria-hidden
+                />
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/features/test-create/ui/QuestionImageUploadSection.tsx
+++ b/src/features/test-create/ui/QuestionImageUploadSection.tsx
@@ -30,19 +30,7 @@ export function QuestionImageUploadSection({ imageUrl, onCameraClick, onRemove }
       <div className="flex flex-nowrap gap-2 px-5 pb-3">
         <button
           type="button"
-          style={{
-            width: 88,
-            height: 88,
-            backgroundColor: "var(--token-tds-color-grey-100, var(--adaptiveGrey100, #f2f4f6))",
-            borderRadius: 16,
-            padding: 16,
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 4,
-            flexShrink: 0,
-          }}
+          className="flex h-[88px] w-[88px] shrink-0 flex-col items-center justify-center gap-1 rounded-2xl p-4 bg-[var(--token-tds-color-grey-100,var(--adaptiveGrey100,#f2f4f6))]"
           onClick={onCameraClick}
         >
           <Asset.Icon
@@ -53,7 +41,7 @@ export function QuestionImageUploadSection({ imageUrl, onCameraClick, onRemove }
             aria-hidden
             ratio="1/1"
           />
-          <div style={{ display: "flex" }}>
+          <div className="flex">
             <Text color={adaptive.grey500} typography="t7" fontWeight="medium">
               {imageCount}
             </Text>
@@ -63,41 +51,13 @@ export function QuestionImageUploadSection({ imageUrl, onCameraClick, onRemove }
           </div>
         </button>
         {imageUrl && (
-          <div
-            style={{
-              position: "relative",
-              width: 88,
-              height: 88,
-              flexShrink: 0,
-              borderRadius: 16,
-              overflow: "hidden",
-            }}
-          >
-            <img src={imageUrl} alt="질문 이미지" style={{ width: "100%", height: "100%", objectFit: "cover" }} />
-            <div
-              style={{
-                position: "absolute",
-                top: 6,
-                left: 6,
-                right: 6,
-                bottom: 6,
-                display: "flex",
-                justifyContent: "flex-end",
-                alignItems: "flex-start",
-                pointerEvents: "none",
-              }}
-            >
+          <div className="relative h-[88px] w-[88px] shrink-0 overflow-hidden rounded-2xl">
+            <img src={imageUrl} alt="질문 이미지" className="h-full w-full object-cover" />
+            <div className="absolute inset-[6px] flex items-start justify-end pointer-events-none">
               <button
                 type="button"
                 onClick={onRemove}
-                style={{
-                  display: "flex",
-                  background: "none",
-                  border: "none",
-                  padding: 0,
-                  cursor: "pointer",
-                  pointerEvents: "auto",
-                }}
+                className="flex p-0 cursor-pointer pointer-events-auto"
                 aria-label="이미지 삭제"
               >
                 <Asset.Icon

--- a/src/features/test-create/ui/QuestionImageUploadSection.tsx
+++ b/src/features/test-create/ui/QuestionImageUploadSection.tsx
@@ -28,28 +28,30 @@ export function QuestionImageUploadSection({ imageUrl, onCameraClick, onRemove }
         }
       />
       <div className="flex flex-nowrap gap-2 px-5 pb-3">
-        <button
-          type="button"
-          className="flex h-[88px] w-[88px] shrink-0 flex-col items-center justify-center gap-1 rounded-2xl p-4 bg-[var(--token-tds-color-grey-100,var(--adaptiveGrey100,#f2f4f6))]"
-          onClick={onCameraClick}
-        >
-          <Asset.Icon
-            frameShape={Asset.frameShape.CleanW24}
-            backgroundColor="transparent"
-            name="icon-camera-mono"
-            color={adaptive.grey600}
-            aria-hidden
-            ratio="1/1"
-          />
-          <div className="flex">
-            <Text color={adaptive.grey500} typography="t7" fontWeight="medium">
-              {imageCount}
-            </Text>
-            <Text color={adaptive.grey500} typography="t7" fontWeight="medium">
-              /1
-            </Text>
-          </div>
-        </button>
+        <div className="h-[88px] w-[88px] shrink-0 overflow-hidden rounded-2xl">
+          <button
+            type="button"
+            className="flex h-full w-full flex-col items-center justify-center gap-1 p-4 bg-[var(--token-tds-color-grey-100,var(--adaptiveGrey100,#f2f4f6))]"
+            onClick={onCameraClick}
+          >
+            <Asset.Icon
+              frameShape={Asset.frameShape.CleanW24}
+              backgroundColor="transparent"
+              name="icon-camera-mono"
+              color={adaptive.grey600}
+              aria-hidden
+              ratio="1/1"
+            />
+            <div className="flex">
+              <Text color={adaptive.grey500} typography="t7" fontWeight="medium">
+                {imageCount}
+              </Text>
+              <Text color={adaptive.grey500} typography="t7" fontWeight="medium">
+                /1
+              </Text>
+            </div>
+          </button>
+        </div>
         {imageUrl && (
           <div className="relative h-[88px] w-[88px] shrink-0 overflow-hidden rounded-2xl">
             <img src={imageUrl} alt="질문 이미지" className="h-full w-full object-cover" />

--- a/src/features/test-create/ui/QuestionManageSheet.tsx
+++ b/src/features/test-create/ui/QuestionManageSheet.tsx
@@ -1,13 +1,11 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { Top, SegmentedControl, FixedBottomCTA, CTAButton, ListRow, Button, IconButton, Text, ConfirmDialog } from "@toss/tds-mobile";
+import { Top, FixedBottomCTA, CTAButton, ListRow, IconButton, Asset, Text, ConfirmDialog } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
-import { DndContext, PointerSensor, useSensor, useSensors, closestCenter, type DragEndEvent } from "@dnd-kit/core";
+import { DndContext, MouseSensor, TouchSensor, useSensor, useSensors, closestCenter, type DragEndEvent } from "@dnd-kit/core";
 import { SortableContext, useSortable, arrayMove, verticalListSortingStrategy } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { QUESTION_TYPES, type PendingQuestion } from "../model/types";
-
-type ManageTab = "delete" | "reorder";
 
 interface QuestionManageSheetProps {
   questions: PendingQuestion[];
@@ -17,22 +15,34 @@ interface QuestionManageSheetProps {
   onCancel: () => void;
 }
 
-function SortableQuestionItem({ question }: { question: PendingQuestion }) {
+interface SortableItemProps {
+  question: PendingQuestion;
+  onDeleteRequest: (id: string) => void;
+}
+
+function SortableQuestionItem({ question, onDeleteRequest }: SortableItemProps) {
   const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({ id: question.id });
   const type = QUESTION_TYPES.find((t) => t.id === question.typeId);
   if (!type) return null;
 
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.5 : 1,
-    touchAction: "manipulation" as const,
-  };
-
   return (
-    <div ref={setNodeRef} style={style}>
+    <div
+      ref={setNodeRef}
+      style={{
+        transform: CSS.Transform.toString(transform),
+        transition,
+        opacity: isDragging ? 0.5 : 1,
+      }}
+      {...attributes}
+      {...listeners}
+    >
       <ListRow
-        left={<ListRow.AssetIcon size="xsmall" shape="original" name={type.iconName} />}
+        left={
+          <div className="flex items-center gap-2">
+            <Asset.Icon frameShape={{ width: 20, height: 20 }} backgroundColor="transparent" name="icon-navigation-menu-mono" color={adaptive.grey400} aria-hidden ratio="1/1" />
+            <ListRow.AssetIcon size="xsmall" shape="original" name={type.iconName} />
+          </div>
+        }
         contents={
           <ListRow.Texts
             type="2RowTypeA"
@@ -43,16 +53,16 @@ function SortableQuestionItem({ question }: { question: PendingQuestion }) {
           />
         }
         right={
-          <IconButton
-            src="https://static.toss.im/icons/png/4x/icon-navigation-menu-mono.png"
-            iconSize={20}
-            variant="clear"
-            color={adaptive.grey400}
-            aria-label="순서 변경 핸들"
-            style={{ touchAction: "none", cursor: "grab" }}
-            {...attributes}
-            {...listeners}
-          />
+          <div onPointerDown={(e) => e.stopPropagation()}>
+            <IconButton
+              src="https://static.toss.im/icons/png/4x/icon-bin-mono.png"
+              iconSize={20}
+              variant="clear"
+              color={adaptive.grey400}
+              aria-label="삭제"
+              onClick={() => onDeleteRequest(question.id)}
+            />
+          </div>
         }
         verticalPadding="large"
       />
@@ -61,10 +71,8 @@ function SortableQuestionItem({ question }: { question: PendingQuestion }) {
 }
 
 export function QuestionManageSheet({ questions, onDelete, onReorder, onSave, onCancel }: QuestionManageSheetProps) {
-  const [activeTab, setActiveTab] = useState<ManageTab>("delete");
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
-  const isSaveDisabled = questions.length === 0;
 
   const closeDeleteDialog = () => setPendingDeleteId(null);
   const confirmDelete = () => {
@@ -78,7 +86,10 @@ export function QuestionManageSheet({ questions, onDelete, onReorder, onSave, on
     onSave();
   };
 
-  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 5 } }));
+  const sensors = useSensors(
+    useSensor(MouseSensor, { activationConstraint: { distance: 5 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } }),
+  );
 
   const handleDragEnd = (event: DragEndEvent) => {
     const { active, over } = event;
@@ -101,55 +112,20 @@ export function QuestionManageSheet({ questions, onDelete, onReorder, onSave, on
         }
       />
 
-      <div className="px-5 mt-4">
-        <SegmentedControl alignment="fixed" size="small" value={activeTab} onChange={(v) => setActiveTab(v as ManageTab)}>
-          <SegmentedControl.Item value="delete">질문 삭제</SegmentedControl.Item>
-          <SegmentedControl.Item value="reorder">순서 바꾸기</SegmentedControl.Item>
-        </SegmentedControl>
-      </div>
-
-      <div className="px-5 pt-6 pb-2">
+      <div className="px-6 pt-6 pb-2">
         <Text color={adaptive.grey700} typography="t7" fontWeight="regular">
-          질문
+          질문 목록
         </Text>
       </div>
 
       <div className="flex-1 overflow-y-auto">
-        {activeTab === "delete" ? (
-          questions.map((q) => {
-            const type = QUESTION_TYPES.find((t) => t.id === q.typeId);
-            if (!type) return null;
-            return (
-              <ListRow
-                key={q.id}
-                left={<ListRow.AssetIcon size="xsmall" shape="original" name={type.iconName} />}
-                contents={
-                  <ListRow.Texts
-                    type="2RowTypeA"
-                    top={q.data?.title ?? "미입력"}
-                    topProps={{ color: adaptive.grey800, fontWeight: "semibold" }}
-                    bottom={type.label}
-                    bottomProps={{ color: adaptive.grey600 }}
-                  />
-                }
-                right={
-                  <Button size="small" color="danger" variant="weak" onClick={() => setPendingDeleteId(q.id)}>
-                    삭제
-                  </Button>
-                }
-                verticalPadding="large"
-              />
-            );
-          })
-        ) : (
-          <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-            <SortableContext items={questions.map((q) => q.id)} strategy={verticalListSortingStrategy}>
-              {questions.map((q) => (
-                <SortableQuestionItem key={q.id} question={q} />
-              ))}
-            </SortableContext>
-          </DndContext>
-        )}
+        <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
+          <SortableContext items={questions.map((q) => q.id)} strategy={verticalListSortingStrategy}>
+            {questions.map((q) => (
+              <SortableQuestionItem key={q.id} question={q} onDeleteRequest={setPendingDeleteId} />
+            ))}
+          </SortableContext>
+        </DndContext>
       </div>
 
       <FixedBottomCTA.Double
@@ -159,7 +135,7 @@ export function QuestionManageSheet({ questions, onDelete, onReorder, onSave, on
           </CTAButton>
         }
         rightButton={
-          <CTAButton className="w-full" disabled={isSaveDisabled} onClick={() => setIsSaveDialogOpen(true)}>
+          <CTAButton className="w-full" disabled={questions.length === 0} onClick={() => setIsSaveDialogOpen(true)}>
             저장하기
           </CTAButton>
         }

--- a/src/features/test-create/ui/QuestionTypeSelectSheet.tsx
+++ b/src/features/test-create/ui/QuestionTypeSelectSheet.tsx
@@ -27,7 +27,7 @@ export function QuestionTypeSelectSheet({ selectedCounts, onChangeCount, existin
       openToast("질문은 최대 20개까지만 만들 수 있어요.", {
         type: "bottom",
         lottie: "https://static.toss.im/lotties-common/error-yellow-spot.json",
-        higherThanCTA: false,
+        higherThanCTA: true,
       });
       return;
     }
@@ -68,7 +68,7 @@ export function QuestionTypeSelectSheet({ selectedCounts, onChangeCount, existin
                     size="tiny"
                     number={count}
                     minNumber={0}
-                    maxNumber={remaining - (totalSelected - count)}
+                    maxNumber={99}
                     disable={false}
                     onNumberChange={(newCount) => handleChangeCount(type.id, newCount)}
                   />

--- a/src/features/test-create/ui/QuestionTypeSelectSheet.tsx
+++ b/src/features/test-create/ui/QuestionTypeSelectSheet.tsx
@@ -1,18 +1,38 @@
 import { motion } from "framer-motion";
-import { FixedBottomCTA, CTAButton, ListRow, Checkbox, Top } from "@toss/tds-mobile";
+import { FixedBottomCTA, CTAButton, ListRow, Top, NumericSpinner, IconButton, useToast } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { QUESTION_TYPES, type QuestionTypeId } from "../model/types";
 
+const MAX_QUESTIONS = 20;
+
 interface QuestionTypeSelectSheetProps {
-  selectedTypes: QuestionTypeId[];
-  onToggle: (id: QuestionTypeId) => void;
+  selectedCounts: Partial<Record<QuestionTypeId, number>>;
+  onChangeCount: (id: QuestionTypeId, count: number) => void;
+  existingCount: number;
   onConfirm: () => void;
   onCancel: () => void;
   onShowGuide?: () => void;
 }
 
-export function QuestionTypeSelectSheet({ selectedTypes, onToggle, onConfirm, onCancel, onShowGuide }: QuestionTypeSelectSheetProps) {
-  const isConfirmDisabled = selectedTypes.length === 0;
+export function QuestionTypeSelectSheet({ selectedCounts, onChangeCount, existingCount, onConfirm, onCancel, onShowGuide }: QuestionTypeSelectSheetProps) {
+  const { openToast } = useToast();
+  const totalSelected = Object.values(selectedCounts).reduce((sum, c) => sum + (c ?? 0), 0);
+  const remaining = MAX_QUESTIONS - existingCount;
+
+  const handleChangeCount = (id: QuestionTypeId, newCount: number) => {
+    const currentForId = selectedCounts[id] ?? 0;
+    const otherTotal = totalSelected - currentForId;
+
+    if (otherTotal + newCount > remaining) {
+      openToast("질문은 최대 20개까지만 만들 수 있어요.", {
+        type: "bottom",
+        lottie: "https://static.toss.im/lotties-common/error-yellow-spot.json",
+        higherThanCTA: false,
+      });
+      return;
+    }
+    onChangeCount(id, newCount);
+  };
 
   return (
     <motion.div className="fixed inset-0 z-50 flex flex-col bg-white" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.2 }}>
@@ -34,26 +54,36 @@ export function QuestionTypeSelectSheet({ selectedTypes, onToggle, onConfirm, on
 
       <div className="flex-1 overflow-y-auto">
         {QUESTION_TYPES.map((type) => {
-          const isSelected = selectedTypes.includes(type.id);
+          const count = selectedCounts[type.id] ?? 0;
           return (
             <ListRow
               key={type.id}
-              as="button"
-              className="w-full text-left"
-              role="checkbox"
-              aria-checked={isSelected}
-              onClick={() => onToggle(type.id)}
               left={<ListRow.AssetIcon size="xsmall" shape="original" name={type.iconName} />}
               contents={
-                <ListRow.Texts
-                  type="2RowTypeA"
-                  top={type.label}
-                  topProps={{ color: adaptive.grey700, fontWeight: "bold" }}
-                  bottom={type.description}
-                  bottomProps={{ color: adaptive.grey600 }}
-                />
+                <ListRow.Texts type="2RowTypeA" top={type.label} topProps={{ color: adaptive.grey700, fontWeight: "bold" }} bottom={type.description} bottomProps={{ color: adaptive.grey600 }} />
               }
-              right={<Checkbox.Line size={24} checked={isSelected} readOnly />}
+              right={
+                count > 0 ? (
+                  <NumericSpinner
+                    size="tiny"
+                    number={count}
+                    minNumber={0}
+                    maxNumber={remaining - (totalSelected - count)}
+                    disable={false}
+                    onNumberChange={(newCount) => handleChangeCount(type.id, newCount)}
+                  />
+                ) : (
+                  <IconButton
+                    src="https://static.toss.im/icons/png/4x/icon-plus-thin-mono.png"
+                    variant="fill"
+                    iconSize={16}
+                    bgColor={adaptive.grey100}
+                    color={adaptive.grey700}
+                    aria-label={`${type.label} 추가`}
+                    onClick={() => handleChangeCount(type.id, 1)}
+                  />
+                )
+              }
               verticalPadding="large"
             />
           );
@@ -67,8 +97,8 @@ export function QuestionTypeSelectSheet({ selectedTypes, onToggle, onConfirm, on
           </CTAButton>
         }
         rightButton={
-          <CTAButton className="w-full" disabled={isConfirmDisabled} onClick={onConfirm}>
-            추가하기
+          <CTAButton className="w-full" disabled={totalSelected === 0} onClick={onConfirm}>
+            {totalSelected > 0 ? `${totalSelected}개 추가하기` : "추가하기"}
           </CTAButton>
         }
       />

--- a/src/features/test-create/ui/TestRegisterStep.tsx
+++ b/src/features/test-create/ui/TestRegisterStep.tsx
@@ -19,7 +19,7 @@ interface TestRegisterStepProps {
 export function TestRegisterStep({ activeTab, onTabChange, onEnterQuestion, onGuideView }: TestRegisterStepProps) {
   const form = useTestCreateForm();
   const [isQuestionTypeSheetOpen, setIsQuestionTypeSheetOpen] = useState(false);
-  const [selectedQuestionTypes, setSelectedQuestionTypes] = useState<QuestionTypeId[]>([]);
+  const [selectedCounts, setSelectedCounts] = useState<Partial<Record<QuestionTypeId, number>>>({});
   const [isManageSheetOpen, setIsManageSheetOpen] = useState(false);
   const [pendingQuestions, setPendingQuestions] = useState<PendingQuestion[]>([]);
   const [activeImageIndex, setActiveImageIndex] = useState(0);
@@ -35,18 +35,21 @@ export function TestRegisterStep({ activeTab, onTabChange, onEnterQuestion, onGu
       .filter(Boolean);
   }, [form.categories]);
 
-  const toggleQuestionType = (id: QuestionTypeId) => {
-    setSelectedQuestionTypes((prev) => (prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id]));
+  const handleChangeCount = (id: QuestionTypeId, count: number) => {
+    setSelectedCounts((prev) => ({ ...prev, [id]: count }));
   };
 
   const closeQuestionTypeSheet = () => {
-    setSelectedQuestionTypes([]);
+    setSelectedCounts({});
     setIsQuestionTypeSheetOpen(false);
   };
 
   const handleConfirmQuestionTypes = () => {
-    form.addQuestions(selectedQuestionTypes);
-    setSelectedQuestionTypes([]);
+    const typeIds = Object.entries(selectedCounts).flatMap(([id, count]) =>
+      Array.from({ length: count ?? 0 }, () => id as QuestionTypeId)
+    );
+    form.addQuestions(typeIds);
+    setSelectedCounts({});
     setIsQuestionTypeSheetOpen(false);
   };
 
@@ -284,7 +287,7 @@ export function TestRegisterStep({ activeTab, onTabChange, onEnterQuestion, onGu
 
       <AnimatePresence>
         {isQuestionTypeSheetOpen && (
-          <QuestionTypeSelectSheet selectedTypes={selectedQuestionTypes} onToggle={toggleQuestionType} onConfirm={handleConfirmQuestionTypes} onCancel={closeQuestionTypeSheet} />
+          <QuestionTypeSelectSheet selectedCounts={selectedCounts} onChangeCount={handleChangeCount} existingCount={form.questions.length} onConfirm={handleConfirmQuestionTypes} onCancel={closeQuestionTypeSheet} />
         )}
         {isManageSheetOpen && (
           <QuestionManageSheet

--- a/src/features/test-create/ui/TestRegisterStep.tsx
+++ b/src/features/test-create/ui/TestRegisterStep.tsx
@@ -1,24 +1,10 @@
 import { useState, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
-import {
-  SegmentedControl,
-  ListRow,
-  Button,
-  Asset,
-  Text,
-  Spacing,
-  Top,
-  List,
-} from "@toss/tds-mobile";
+import { SegmentedControl, ListRow, Button, Asset, Text, Spacing, Top, List } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { QuestionTypeSelectSheet } from "./QuestionTypeSelectSheet";
 import { QuestionManageSheet } from "./QuestionManageSheet";
-import {
-  QUESTION_TYPES,
-  CATEGORIES,
-  type QuestionTypeId,
-  type PendingQuestion,
-} from "../model/types";
+import { QUESTION_TYPES, CATEGORIES, type QuestionTypeId, type PendingQuestion } from "../model/types";
 import { useTestCreateForm } from "../model/useTestCreateForm";
 
 export type RegisterTab = "info" | "questions";
@@ -27,22 +13,15 @@ interface TestRegisterStepProps {
   activeTab: RegisterTab;
   onTabChange: (tab: RegisterTab) => void;
   onEnterQuestion: (question: { id: string; typeId: QuestionTypeId }) => void;
+  onGuideView?: () => void;
 }
 
-export function TestRegisterStep({
-  activeTab,
-  onTabChange,
-  onEnterQuestion,
-}: TestRegisterStepProps) {
+export function TestRegisterStep({ activeTab, onTabChange, onEnterQuestion, onGuideView }: TestRegisterStepProps) {
   const form = useTestCreateForm();
   const [isQuestionTypeSheetOpen, setIsQuestionTypeSheetOpen] = useState(false);
-  const [selectedQuestionTypes, setSelectedQuestionTypes] = useState<
-    QuestionTypeId[]
-  >([]);
+  const [selectedQuestionTypes, setSelectedQuestionTypes] = useState<QuestionTypeId[]>([]);
   const [isManageSheetOpen, setIsManageSheetOpen] = useState(false);
-  const [pendingQuestions, setPendingQuestions] = useState<PendingQuestion[]>(
-    [],
-  );
+  const [pendingQuestions, setPendingQuestions] = useState<PendingQuestion[]>([]);
   const [activeImageIndex, setActiveImageIndex] = useState(0);
 
   const hasQuestions = form.questions.length > 0;
@@ -57,9 +36,7 @@ export function TestRegisterStep({
   }, [form.categories]);
 
   const toggleQuestionType = (id: QuestionTypeId) => {
-    setSelectedQuestionTypes((prev) =>
-      prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id],
-    );
+    setSelectedQuestionTypes((prev) => (prev.includes(id) ? prev.filter((t) => t !== id) : [...prev, id]));
   };
 
   const closeQuestionTypeSheet = () => {
@@ -90,25 +67,11 @@ export function TestRegisterStep({
 
   return (
     <>
-      <motion.div
-        key="register"
-        className="flex flex-col flex-1"
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ duration: 0.2 }}
-      >
+      <motion.div key="register" className="flex flex-col flex-1" initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
         <div className="pt-4">
-          <SegmentedControl
-            size="large"
-            value={activeTab}
-            onChange={(v) => onTabChange(v as RegisterTab)}
-          >
-            <SegmentedControl.Item value="info">
-              테스트 정보
-            </SegmentedControl.Item>
-            <SegmentedControl.Item value="questions">
-              질문 목록
-            </SegmentedControl.Item>
+          <SegmentedControl size="large" value={activeTab} onChange={(v) => onTabChange(v as RegisterTab)}>
+            <SegmentedControl.Item value="info">테스트 정보</SegmentedControl.Item>
+            <SegmentedControl.Item value="questions">질문 목록</SegmentedControl.Item>
           </SegmentedControl>
         </div>
 
@@ -117,24 +80,22 @@ export function TestRegisterStep({
             <ListRow
               as="button"
               className="text-left"
+              left={<ListRow.AssetIcon size="xsmall" shape="original" name="icon-question-circle-mono" color="#4365cb" />}
+              contents={<ListRow.Texts type="2RowTypeF" top="질문 유형" topProps={{ color: adaptive.grey500 }} bottom="가이드 보기" bottomProps={{ color: adaptive.grey800, fontWeight: `bold` }} />}
+              verticalPadding="large"
+              arrowType="right"
+              withTouchEffect
+              onClick={onGuideView}
+            />
+            <ListRow
+              as="button"
+              className="text-left"
               style={{
                 backgroundColor: "var(--adaptiveCardBgGrey)",
                 margin: "0 20px",
               }}
-              left={
-                <ListRow.AssetIcon
-                  shape="original"
-                  name="icon-plus-grey-fill"
-                  variant="fill"
-                />
-              }
-              contents={
-                <ListRow.Texts
-                  type="1RowTypeA"
-                  top={hasQuestions ? "추가하기" : "만들기"}
-                  topProps={{ color: adaptive.grey700 }}
-                />
-              }
+              left={<ListRow.AssetIcon shape="original" name="icon-plus-grey-fill" variant="fill" />}
+              contents={<ListRow.Texts type="1RowTypeA" top={hasQuestions ? "추가하기" : "만들기"} topProps={{ color: adaptive.grey700 }} />}
               verticalPadding="large"
               horizontalPadding="small"
               onClick={() => setIsQuestionTypeSheetOpen(true)}
@@ -150,13 +111,7 @@ export function TestRegisterStep({
                     <ListRow
                       key={q.id}
                       style={{ margin: "0 4px" }}
-                      left={
-                        <ListRow.AssetIcon
-                          size="xsmall"
-                          shape="original"
-                          name={type.iconName}
-                        />
-                      }
+                      left={<ListRow.AssetIcon size="xsmall" shape="original" name={type.iconName} />}
                       contents={
                         <ListRow.Texts
                           type="2RowTypeA"
@@ -170,14 +125,7 @@ export function TestRegisterStep({
                         />
                       }
                       right={
-                        <Button
-                          size="small"
-                          variant={isFilled ? "weak" : "fill"}
-                          color={isFilled ? "dark" : undefined}
-                          onClick={() =>
-                            onEnterQuestion({ id: q.id, typeId: q.typeId })
-                          }
-                        >
+                        <Button size="small" variant={isFilled ? "weak" : "fill"} color={isFilled ? "dark" : undefined} onClick={() => onEnterQuestion({ id: q.id, typeId: q.typeId })}>
                           {isFilled ? "수정" : "입력"}
                         </Button>
                       }
@@ -192,25 +140,13 @@ export function TestRegisterStep({
                     className="flex items-center h-12 bg-white px-3"
                     style={{
                       borderRadius: 25,
-                      boxShadow:
-                        "0px 20px 20px -16px #191F2911, 0px 40px 200px 0px #191F293f, inset 0 0 0 1px rgba(2,32,71,0.05)",
+                      boxShadow: "0px 20px 20px -16px #191F2911, 0px 40px 200px 0px #191F293f, inset 0 0 0 1px rgba(2,32,71,0.05)",
                     }}
                     onClick={openEditSheet}
                   >
                     <div className="flex items-center gap-1 h-8">
-                      <Asset.Icon
-                        frameShape={Asset.frameShape.CleanW24}
-                        backgroundColor="transparent"
-                        name="icon-setting-mono"
-                        color={adaptive.grey600}
-                        aria-hidden
-                        ratio="1/1"
-                      />
-                      <Text
-                        color={adaptive.grey800}
-                        typography="t5"
-                        fontWeight="medium"
-                      >
+                      <Asset.Icon frameShape={Asset.frameShape.CleanW24} backgroundColor="transparent" name="icon-setting-mono" color={adaptive.grey600} aria-hidden ratio="1/1" />
+                      <Text color={adaptive.grey800} typography="t5" fontWeight="medium">
                         편집하기
                       </Text>
                     </div>
@@ -219,12 +155,8 @@ export function TestRegisterStep({
               </>
             ) : (
               <div className="flex-1 flex flex-col items-center justify-center px-4">
-                <p className="text-[17px] font-semibold text-[#191F28]">
-                  등록한 질문이 없어요
-                </p>
-                <p className="mt-2 text-[15px] text-[#6B7684]">
-                  질문을 등록하고 테스트를 구성해봐요
-                </p>
+                <p className="text-[17px] font-semibold text-[#191F28]">등록한 질문이 없어요</p>
+                <p className="mt-2 text-[15px] text-[#6B7684]">질문을 등록하고 테스트를 구성해봐요</p>
               </div>
             )}
           </div>
@@ -239,19 +171,8 @@ export function TestRegisterStep({
                 opacity: 1,
                 margin: "0 20px",
               }}
-              left={
-                <ListRow.AssetIcon
-                  name="icon-phone"
-                  backgroundColor={adaptive.greyOpacity100}
-                />
-              }
-              contents={
-                <ListRow.Texts
-                  type="1RowTypeB"
-                  top="실제 테스터에게 보이는 화면이에요"
-                  topProps={{ color: adaptive.grey700 }}
-                />
-              }
+              left={<ListRow.AssetIcon name="icon-phone" backgroundColor={adaptive.greyOpacity100} />}
+              contents={<ListRow.Texts type="1RowTypeB" top="실제 테스터에게 보이는 화면이에요" topProps={{ color: adaptive.grey700 }} />}
               horizontalPadding="small"
             />
             <Top
@@ -277,12 +198,7 @@ export function TestRegisterStep({
                 />
               }
               lower={
-                <Top.LowerButton
-                  color="primary"
-                  size="small"
-                  variant="weak"
-                  display="inline"
-                >
+                <Top.LowerButton color="primary" size="small" variant="weak" display="inline">
                   어떤 서비스인가요?
                 </Top.LowerButton>
               }
@@ -292,23 +208,12 @@ export function TestRegisterStep({
               style={{ gap: "12px", margin: "0 20px" }}
               onScroll={(e) => {
                 const target = e.target as HTMLDivElement;
-                const index = Math.round(
-                  target.scrollLeft / target.clientWidth,
-                );
+                const index = Math.round(target.scrollLeft / target.clientWidth);
                 setActiveImageIndex(index);
               }}
             >
-              {(form.images.length > 0
-                ? form.images
-                : [
-                    "https://static.toss.im/appsintoss/33213/ac1b1d5e-c6d7-4943-9236-fcbd2bc825c0.png",
-                  ]
-              ).map((src, i) => (
-                <div
-                  key={i}
-                  className="snap-start shrink-0 w-full"
-                  style={{ aspectRatio: "16/9" }}
-                >
+              {(form.images.length > 0 ? form.images : ["https://static.toss.im/appsintoss/33213/ac1b1d5e-c6d7-4943-9236-fcbd2bc825c0.png"]).map((src, i) => (
+                <div key={i} className="snap-start shrink-0 w-full" style={{ aspectRatio: "16/9" }}>
                   <img
                     src={src}
                     aria-hidden={true}
@@ -324,34 +229,22 @@ export function TestRegisterStep({
             </div>
             <Spacing size={16} />
             <div className="flex justify-center gap-1.5">
-              {Array.from({ length: Math.max(form.images.length, 1) }).map(
-                (_, i) => (
-                  <Asset.Icon
-                    key={i}
-                    frameShape={{ width: 12, height: 12 }}
-                    backgroundColor="transparent"
-                    name="icon-circle-16-mono"
-                    color={
-                      i === activeImageIndex
-                        ? adaptive.greyOpacity500
-                        : adaptive.greyOpacity300
-                    }
-                    aria-hidden={true}
-                    ratio="1/1"
-                  />
-                ),
-              )}
+              {Array.from({ length: Math.max(form.images.length, 1) }).map((_, i) => (
+                <Asset.Icon
+                  key={i}
+                  frameShape={{ width: 12, height: 12 }}
+                  backgroundColor="transparent"
+                  name="icon-circle-16-mono"
+                  color={i === activeImageIndex ? adaptive.greyOpacity500 : adaptive.greyOpacity300}
+                  aria-hidden={true}
+                  ratio="1/1"
+                />
+              ))}
             </div>
             <Spacing size={20} />
             <List>
               <ListRow
-                left={
-                  <ListRow.AssetIcon
-                    size="medium"
-                    name="icon-coin-yellow"
-                    backgroundColor={adaptive.yellow100}
-                  />
-                }
+                left={<ListRow.AssetIcon size="medium" name="icon-coin-yellow" backgroundColor={adaptive.yellow100} />}
                 contents={
                   <ListRow.Texts
                     type="2RowTypeF"
@@ -368,13 +261,7 @@ export function TestRegisterStep({
                 horizontalPadding="small"
               />
               <ListRow
-                left={
-                  <ListRow.AssetIcon
-                    size="medium"
-                    name="icon-document-teal"
-                    backgroundColor={adaptive.green100}
-                  />
-                }
+                left={<ListRow.AssetIcon size="medium" name="icon-document-teal" backgroundColor={adaptive.green100} />}
                 contents={
                   <ListRow.Texts
                     type="2RowTypeF"
@@ -397,19 +284,12 @@ export function TestRegisterStep({
 
       <AnimatePresence>
         {isQuestionTypeSheetOpen && (
-          <QuestionTypeSelectSheet
-            selectedTypes={selectedQuestionTypes}
-            onToggle={toggleQuestionType}
-            onConfirm={handleConfirmQuestionTypes}
-            onCancel={closeQuestionTypeSheet}
-          />
+          <QuestionTypeSelectSheet selectedTypes={selectedQuestionTypes} onToggle={toggleQuestionType} onConfirm={handleConfirmQuestionTypes} onCancel={closeQuestionTypeSheet} />
         )}
         {isManageSheetOpen && (
           <QuestionManageSheet
             questions={pendingQuestions}
-            onDelete={(id) =>
-              setPendingQuestions((prev) => prev.filter((q) => q.id !== id))
-            }
+            onDelete={(id) => setPendingQuestions((prev) => prev.filter((q) => q.id !== id))}
             onReorder={setPendingQuestions}
             onSave={handleSaveManage}
             onCancel={closeManageSheet}

--- a/src/features/test-create/ui/useQuestionCreateTopSectionHooks.ts
+++ b/src/features/test-create/ui/useQuestionCreateTopSectionHooks.ts
@@ -1,0 +1,75 @@
+import { useState, useEffect, useRef } from "react";
+import type { EditSheetConfig } from "./QuestionEditSheet";
+
+export function useFocusState() {
+  const [isFocused, setIsFocused] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  return {
+    isFocused,
+    onFocus: () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setIsFocused(true);
+    },
+    onBlur: () => {
+      timerRef.current = setTimeout(() => setIsFocused(false), 100);
+    },
+    blur: () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      setIsFocused(false);
+      (document.activeElement as HTMLElement)?.blur();
+    },
+  };
+}
+
+export type EditingField = "title" | "description";
+
+export function useEditSheet(questionType: string, titlePlaceholder: string) {
+  const [editingField, setEditingField] = useState<EditingField | null>(null);
+  const [draft, setDraft] = useState("");
+  const [fieldVisible, setFieldVisible] = useState(false);
+  const draftRef = useRef("");
+
+  useEffect(() => {
+    if (editingField === null) return;
+    setDraft(draftRef.current);
+    const t = setTimeout(() => setFieldVisible(true), 4);
+    return () => {
+      clearTimeout(t);
+      setFieldVisible(false);
+    };
+  }, [editingField]);
+
+  const config: EditSheetConfig =
+    editingField === "title"
+      ? {
+          header: "어떻게 질문할까요?",
+          label: `${questionType} 질문`,
+          fieldPlaceholder: titlePlaceholder,
+          maxLength: 34,
+        }
+      : {
+          header: "(선택) 질문에 대한 추가 설명을 할까요?",
+          label: "추가 설명",
+          fieldPlaceholder: "추가 설명을 입력해주세요",
+          maxLength: 55,
+        };
+
+  return {
+    editingField,
+    draft,
+    fieldVisible,
+    config,
+    confirmDisabled: editingField === "title" && draft.trim().length === 0,
+    open: (field: EditingField, initialValue: string) => {
+      draftRef.current = initialValue;
+      setDraft(initialValue);
+      setEditingField(field);
+    },
+    close: () => {
+      setEditingField(null);
+      setDraft("");
+    },
+    setDraft,
+  };
+}


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [x] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #56

## 👩🏻‍💻 작업 사항

### 테스트 등록 > 질문 목록 탭 UI 수정
- 가이드 보기 버튼 추가 (`QuestionManageSheet`, `QuestionTypeSelectSheet`)
- `TestRegisterStep` 레이아웃 정리

### 질문 추가 페이지 UI 수정
- 유형별 create 페이지(`Multiple`, `Subjective`, `Scale`, `Fivesec`, `Tree`, `Ab`, `CardSort`) 공통 레이아웃에 맞게 정리

### 질문 편집 페이지 UI 수정
- `QuestionEditSheet` 신규 개발 — 질문 편집 시트 컴포넌트

### 유형별 질문 입력 공통 헤더 구현
- `QuestionCreateTopSection` 리팩터 및 기능 확장 (질문 번호, 제목 입력, 필수 여부 토글)
- `QuestionImageUploadSection` 신규 개발 — 이미지 업로드 공통 컴포넌트
- `useQuestionImageUpload` 훅 신규 개발 — 이미지 업로드 상태/로직 분리

## 📢 기타(공유 사항)
- 각 질문 유형 create 페이지가 `QuestionCreateTopSection`을 공통으로 사용하도록 통일했습니다.
- 이미지 업로드 로직을 `useQuestionImageUpload` 훅으로 분리해 재사용성을 높였습니다.