### PR TITLE
[FIX] UI 피드백 수정 (#67)

### DIFF
--- a/src/features/question-fivesec/answer/FivesecAnswerPage.tsx
+++ b/src/features/question-fivesec/answer/FivesecAnswerPage.tsx
@@ -14,9 +14,10 @@ interface Props extends QuestionAnswerProps<"fivesec"> {
   isFirst: boolean;
   isLast: boolean;
   prevLabel?: string;
+  isPreview?: boolean;
 }
 
-export function FivesecAnswerPage({ question, answer, onChange, onPrev, onGoNext, isFirst, isLast, prevLabel }: Props) {
+export function FivesecAnswerPage({ question, answer, onChange, onPrev, onGoNext, isFirst, isLast, prevLabel, isPreview }: Props) {
   const { duration, isMultiSelectEnabled, minSelectCount, maxSelectCount, choices, imageUrl, ratio } = question.data;
 
   const [phase, setPhase] = useState<Phase>("ready");
@@ -81,7 +82,7 @@ export function FivesecAnswerPage({ question, answer, onChange, onPrev, onGoNext
   }
 
   if (phase === "countdown") {
-    return <FivesecCountdownPhase remaining={remaining} imageUrl={imageUrl} ratio={ratio ?? "9:16"} />;
+    return <FivesecCountdownPhase remaining={remaining} imageUrl={imageUrl} ratio={ratio ?? "9:16"} hideCountdown={isPreview} />;
   }
 
   if (isSubjective) {
@@ -95,6 +96,7 @@ export function FivesecAnswerPage({ question, answer, onChange, onPrev, onGoNext
         isFirst={isFirst}
         isLast={isLast}
         prevLabel={prevLabel}
+        onlyPrev={isPreview}
         onChange={(text) => onChange({ type: "fivesec", selectedIds: [], text })}
         onPrev={onPrev}
         onGoNext={onGoNext}

--- a/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
@@ -12,9 +12,10 @@ interface Props {
   remaining: number;
   imageUrl: string;
   ratio: AbRatio;
+  hideCountdown?: boolean;
 }
 
-export function FivesecCountdownPhase({ remaining, imageUrl, ratio }: Props) {
+export function FivesecCountdownPhase({ remaining, imageUrl, ratio, hideCountdown }: Props) {
   return (
     <motion.div
       className="flex flex-col flex-1 bg-white"
@@ -35,12 +36,14 @@ export function FivesecCountdownPhase({ remaining, imageUrl, ratio }: Props) {
           }}
         >
           <img src={imageUrl} alt="5초 테스트 이미지" className="h-full w-full object-cover" />
-          <div
-            className="absolute inset-0 flex items-center justify-center"
-            style={{ backgroundColor: "rgba(0,0,0,0.35)" }}
-          >
-            <span className="text-5xl font-bold text-white">{remaining}</span>
-          </div>
+          {!hideCountdown && (
+            <div
+              className="absolute inset-0 flex items-center justify-center"
+              style={{ backgroundColor: "rgba(0,0,0,0.35)" }}
+            >
+              <span className="text-5xl font-bold text-white">{remaining}</span>
+            </div>
+          )}
         </div>
       </div>
       <div className="h-18 shrink-0" aria-hidden={true} />

--- a/src/features/question-fivesec/answer/FivesecSubjectiveAnswerPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecSubjectiveAnswerPhase.tsx
@@ -10,6 +10,7 @@ interface Props {
   isFirst: boolean;
   isLast: boolean;
   prevLabel?: string;
+  onlyPrev?: boolean;
   onChange: (text: string) => void;
   onPrev: () => void;
   onGoNext: () => void;
@@ -24,6 +25,7 @@ export function FivesecSubjectiveAnswerPhase({
   isFirst,
   isLast,
   prevLabel = "이전",
+  onlyPrev,
   onChange,
   onPrev,
   onGoNext,
@@ -57,7 +59,9 @@ export function FivesecSubjectiveAnswerPhase({
           onChange={(e) => onChange(e.target.value)}
         />
       </div>
-      {isFirst ? (
+      {onlyPrev ? (
+        <FixedBottomCTA onClick={onPrev}>{prevLabel}</FixedBottomCTA>
+      ) : isFirst ? (
         <FixedBottomCTA disabled={!canGoNext} onClick={onGoNext}>
           {isLast ? "완료하기" : "다음"}
         </FixedBottomCTA>

--- a/src/features/question-fivesec/create/FivesecCreatePage.tsx
+++ b/src/features/question-fivesec/create/FivesecCreatePage.tsx
@@ -420,6 +420,7 @@ export function FivesecCreatePage({
             isFirst={false}
             isLast={true}
             prevLabel="돌아가기"
+            isPreview={true}
           />
         </motion.div>
       )}

--- a/src/features/question-scale/create/ScaleCreateOptionSection.tsx
+++ b/src/features/question-scale/create/ScaleCreateOptionSection.tsx
@@ -1,10 +1,8 @@
 import { useState } from "react";
-import { IconButton, ListHeader, ListRow, Switch, Text } from "@toss/tds-mobile";
+import { Asset, ListHeader, ListRow, Switch } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { ScaleLabelEditSheet } from "./ScaleLabelEditSheet";
 
-const SCALE_POINT_CONNECTOR_ICON_SRC =
-  "https://static.toss.im/icons/png/4x/icon-o-mono.png";
 
 interface ScaleCreateOptionSectionProps {
   scaleCount: 5 | 7;
@@ -40,19 +38,17 @@ export function ScaleCreateOptionSection({
         className="w-full"
       />
 
-      <div className="flex w-full items-end justify-center px-3 py-3">
+      <div className={`flex flex-row px-4 mt-3 mb-1 ${scaleCount === 7 ? "justify-between" : "justify-center gap-3"}`}>
         {Array.from({ length: scaleCount }, (_, i) => i + 1).map((point) => (
-          <div key={point} className="flex flex-col items-center gap-1">
-            <Text color={adaptive.grey500} typography="t7" fontWeight="bold">
-              {point}
-            </Text>
-            <IconButton
-              src={SCALE_POINT_CONNECTOR_ICON_SRC}
-              iconSize={24}
-              variant="clear"
-              color={adaptive.grey600}
-              aria-label={`${point}점 척도 표시`}
-            />
+          <div key={point} className="flex items-center justify-center">
+            <Asset.Text
+              frameShape={Asset.frameShape.CircleLarge}
+              backgroundColor={adaptive.greyOpacity100}
+              style={{ color: adaptive.grey600, fontSize: "15px", fontWeight: "bold" }}
+              aria-label={`${point}점`}
+            >
+              {String(point)}
+            </Asset.Text>
           </div>
         ))}
       </div>

--- a/src/features/test-create/ui/BasicInfoEditPage.tsx
+++ b/src/features/test-create/ui/BasicInfoEditPage.tsx
@@ -62,12 +62,12 @@ export function BasicInfoEditPage({ onClose }: BasicInfoEditPageProps) {
       <main className="flex flex-col flex-1">
         <TextField.Clearable
           variant="line"
-          label="테스트 이름"
+          label="테스트 제목"
           labelOption="sustain"
           value={form.name}
           onChange={(e) => form.setName(e.target.value)}
           onClear={() => form.setName("")}
-          placeholder="테스트 이름"
+          placeholder="테스트 제목"
         />
         <TextField.Clearable
           variant="line"

--- a/src/features/test-create/ui/QuestionCreateTopSection.tsx
+++ b/src/features/test-create/ui/QuestionCreateTopSection.tsx
@@ -243,20 +243,24 @@ export function QuestionCreateTopSection({
       ) : (
         <>
           <ClickableTopRow label={`${questionType} 질문`} text={questionTitle} placeholder={placeholder} onClick={() => sheet.open("title", questionTitle)} />
-          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
-            <TextField.Clearable
-              variant="line"
-              label="(선택) 추가 설명을 할까요?"
-              labelOption="sustain"
-              value={questionDescription}
-              placeholder="추가 설명을 입력해주세요"
-              maxLength={55}
-              onChange={(e) => onChangeDescription(e.target.value.slice(0, 55))}
-              onClear={() => onChangeDescription("")}
-              onFocus={descFocus.onFocus}
-              onBlur={descFocus.onBlur}
-            />
-          </motion.div>
+          {questionDescription.trim().length > 0 && !descFocus.isFocused ? (
+            <ClickableTopRow label="(선택) 추가 설명" text={questionDescription} placeholder="추가 설명을 입력해주세요" onClick={() => sheet.open("description", questionDescription)} />
+          ) : (
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} transition={{ duration: 0.2 }}>
+              <TextField.Clearable
+                variant="line"
+                label="(선택) 추가 설명을 할까요?"
+                labelOption="sustain"
+                value={questionDescription}
+                placeholder="추가 설명을 입력해주세요"
+                maxLength={55}
+                onChange={(e) => onChangeDescription(e.target.value.slice(0, 55))}
+                onClear={() => onChangeDescription("")}
+                onFocus={descFocus.onFocus}
+                onBlur={descFocus.onBlur}
+              />
+            </motion.div>
+          )}
           {imageUploadSection}
           <PhaseBottomCTA
             isFocused={descFocus.isFocused}

--- a/src/features/test-create/ui/TestBasicInfoStep.tsx
+++ b/src/features/test-create/ui/TestBasicInfoStep.tsx
@@ -7,7 +7,7 @@ const STEP_CONFIG: Record<
   Exclude<BasicSubStep, "category">,
   { label: string; placeholder: string; maxLength?: number; help?: string }
 > = {
-  name: { label: "테스트 이름", placeholder: "테스트 이름" },
+  name: { label: "테스트 제목", placeholder: "테스트 제목" },
   summary: { label: "테스트 한줄 소개", placeholder: "테스트 한줄 소개", maxLength: 60, help: "최대 60자" },
 };
 


### PR DESCRIPTION
- 질문 추가 설명 입력 후 포커스 해제 시 연필 아이콘 row로 전환
- 5초 테스트 생성 미리보기에서 카운트다운 숫자/overlay 제거
- 5초 주관식 생성 미리보기 CTA를 돌아가기 단일 버튼으로 통합
- 척도 생성 화면 숫자 스타일을 답변 화면과 동일한 원형으로 변경
- 테스트 기본정보 이름 → 제목 레이블 수정

## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [ ] 버그 수정
-   [x] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #67 

## 👩🏻‍💻 작업 사항
<!-- 주요 작업 내용을 간단히 작성해주세요.(스크린샷도 있으면 좋아요!) -->

## 📢 기타(공유 사항) 
<!-- 공유할 내용, 추가 논의가 필요한 사항, 배포 시 유의사항 등을 작성해주세요. -->
