### PR TITLE
[FEAT] 테스트 등록 api 연동

### DIFF
--- a/src/features/test-create/model/useSubmitTest.ts
+++ b/src/features/test-create/model/useSubmitTest.ts
@@ -1,7 +1,7 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useToast } from "@toss/tds-mobile";
-import { HTTPError } from "ky";
+import ky, { HTTPError } from "ky";
 import { createTest } from "@/shared/api/generated/test";
 import { createQuestions } from "@/shared/api/generated/question";
 import { generateUploadUrl } from "@/shared/api/generated/file";
@@ -73,16 +73,9 @@ async function uploadBase64(dataUri: string | undefined): Promise<string | undef
   const { presignedUrl, fileKey } = uploadResponse.data.data ?? {};
   if (!presignedUrl || !fileKey) throw new Error("업로드 URL 발급 실패");
 
-  await new Promise<void>((resolve, reject) => {
-    const xhr = new XMLHttpRequest();
-    xhr.open("PUT", presignedUrl);
-    xhr.setRequestHeader("x-ms-blob-type", "BlockBlob");
-    xhr.onload = () => {
-      if (xhr.status >= 200 && xhr.status < 300) resolve();
-      else reject(new Error(`이미지 업로드 실패 (${xhr.status})`));
-    };
-    xhr.onerror = () => reject(new Error(`이미지 업로드 네트워크 오류 (XHR)`));
-    xhr.send(blob);
+  await ky.put(presignedUrl, {
+    body: blob,
+    headers: { "x-ms-blob-type": "BlockBlob" },
   });
 
   return fileKey;
@@ -165,13 +158,13 @@ async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestIt
         type: "TREE_TEST",
         title: data.title,
         description: data.description,
-        features: data.nodes.map((node) => ({
+        features: data.nodes?.map((node) => ({
           label: node.name,
-          children: node.children.map((child) => ({
+          children: node.children?.map((child) => ({
             label: child.name,
-            children: child.children.length > 0 ? child.children : undefined,
+            children: child.children?.length > 0 ? child.children : undefined,
           })),
-        })),
+        })) ?? [],
       } satisfies TreeTestCreateRequest;
     }
 

--- a/src/features/test-create/model/useSubmitTest.ts
+++ b/src/features/test-create/model/useSubmitTest.ts
@@ -1,0 +1,270 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useToast } from "@toss/tds-mobile";
+import { HTTPError } from "ky";
+import { createTest } from "@/shared/api/generated/test";
+import { createQuestions } from "@/shared/api/generated/question";
+import { generateUploadUrl } from "@/shared/api/generated/file";
+import type { TestCreateRequestCategoriesItem } from "@/shared/api/generated/test";
+import type {
+  AbTestCreateRequest,
+  CardSortingCreateRequest,
+  FiveSecondCreateRequest,
+  ObjectiveCreateRequest,
+  ScaleCreateRequest,
+  SubjectiveCreateRequest,
+  TreeTestCreateRequest,
+} from "@/shared/api/generated/question";
+import { useTestCreateForm } from "./useTestCreateForm";
+import type { CategoryId, PendingQuestion } from "./types";
+import { ROUTES } from "@/shared/constants/routes";
+
+type QuestionRequestItem =
+  | AbTestCreateRequest
+  | CardSortingCreateRequest
+  | FiveSecondCreateRequest
+  | ObjectiveCreateRequest
+  | ScaleCreateRequest
+  | SubjectiveCreateRequest
+  | TreeTestCreateRequest;
+
+const CATEGORY_MAP: Record<CategoryId, TestCreateRequestCategoriesItem> = {
+  daily: "DAILY",
+  finance: "FINANCE",
+  health: "HEALTH",
+  shopping: "SHOPPING",
+  food: "FOOD",
+  game: "GAME",
+  content: "CONTENT",
+  community: "COMMUNITY",
+  ai: "AI",
+  education: "EDUCATION",
+  travel: "TRAVEL",
+  social: "SOCIAL",
+  convenience: "CONVENIENCE",
+  information: "INFORMATION",
+  business: "BUSINESS",
+  transportation: "TRANSPORT",
+  public: "PUBLIC_ADMIN",
+};
+
+function dataUriToBlob(dataUri: string): Blob {
+  const [header, base64] = dataUri.split(",");
+  const mime = header.match(/:(.*?);/)?.[1] ?? "image/jpeg";
+  const binary = atob(base64);
+  const array = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    array[i] = binary.charCodeAt(i);
+  }
+  return new Blob([array], { type: mime });
+}
+
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024;
+
+async function uploadBase64(dataUri: string | undefined): Promise<string | undefined> {
+  if (!dataUri?.startsWith("data:")) return undefined;
+
+  const blob = dataUriToBlob(dataUri);
+  if (blob.size > MAX_IMAGE_BYTES) {
+    throw new Error(`이미지 크기가 10MB를 초과해요 (${(blob.size / 1024 / 1024).toFixed(1)}MB)`);
+  }
+
+  const uploadResponse = await generateUploadUrl({ extension: "jpg" });
+  const { presignedUrl, fileKey } = uploadResponse.data.data ?? {};
+  if (!presignedUrl || !fileKey) throw new Error("업로드 URL 발급 실패");
+
+  await new Promise<void>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    xhr.open("PUT", presignedUrl);
+    xhr.setRequestHeader("x-ms-blob-type", "BlockBlob");
+    xhr.onload = () => {
+      if (xhr.status >= 200 && xhr.status < 300) resolve();
+      else reject(new Error(`이미지 업로드 실패 (${xhr.status})`));
+    };
+    xhr.onerror = () => reject(new Error(`이미지 업로드 네트워크 오류 (XHR)`));
+    xhr.send(blob);
+  });
+
+  return fileKey;
+}
+
+async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestItem | null> {
+  if (!question.data) return null;
+  const data = question.data;
+
+  switch (data.typeId) {
+    case "multiple": {
+      const options = await Promise.all(
+        data.choices.map(async (c) => ({
+          content: c.name,
+          imageKey: await uploadBase64(c.imageUrl || undefined),
+        }))
+      );
+      return {
+        type: "OBJECTIVE",
+        title: data.title,
+        description: data.description,
+        isDuplicate: data.isMultiSelectEnabled,
+        maxSelect: data.isMultiSelectEnabled ? data.maxSelectCount : undefined,
+        minSelect: data.isMultiSelectEnabled ? data.minSelectCount : undefined,
+        isOther: data.isOtherInputEnabled,
+        options,
+      } satisfies ObjectiveCreateRequest;
+    }
+
+    case "subjective": {
+      const imageKey = await uploadBase64(data.imageUrl || undefined);
+      return {
+        type: "SUBJECTIVE",
+        title: data.title,
+        description: data.description,
+        imageKey,
+      } satisfies SubjectiveCreateRequest;
+    }
+
+    case "scale": {
+      const imageKey = await uploadBase64(data.imageUrl || undefined);
+      return {
+        type: "SCALE",
+        title: data.title,
+        description: data.description,
+        imageKey,
+        minLabel: data.minLabel,
+        maxLabel: data.maxLabel,
+        range: data.scaleCount,
+      } satisfies ScaleCreateRequest;
+    }
+
+    case "ab": {
+      const [aImageKey, bImageKey] = await Promise.all([
+        uploadBase64(data.imageUrlA || undefined),
+        uploadBase64(data.imageUrlB || undefined),
+      ]);
+      return {
+        type: "AB_TEST",
+        title: data.title,
+        description: data.description,
+        aImageKey,
+        bImageKey,
+        imageRatio: data.ratio ?? "1:1",
+      } satisfies AbTestCreateRequest;
+    }
+
+    case "card": {
+      return {
+        type: "CARD_SORTING",
+        title: data.title,
+        description: data.description,
+        cards: data.cards.map((c) => c.label),
+        categories: data.categories.map((c) => c.label),
+      } satisfies CardSortingCreateRequest;
+    }
+
+    case "tree": {
+      return {
+        type: "TREE_TEST",
+        title: data.title,
+        description: data.description,
+        features: data.nodes.map((node) => ({
+          label: node.name,
+          children: node.children.map((child) => ({
+            label: child.name,
+            children: child.children.length > 0 ? child.children : undefined,
+          })),
+        })),
+      } satisfies TreeTestCreateRequest;
+    }
+
+    case "fivesec": {
+      const imageKey = await uploadBase64(data.imageUrl || undefined);
+      const isObjective = data.answerType === "multiple";
+      return {
+        type: "FIVE_SECOND",
+        title: data.title,
+        description: data.description,
+        imageKey,
+        imageRatio: data.ratio ?? "1:1",
+        isObjective,
+        isDuplicate: isObjective ? data.isMultiSelectEnabled : undefined,
+        minSelect: isObjective && data.isMultiSelectEnabled ? data.minSelectCount : undefined,
+        maxSelect: isObjective && data.isMultiSelectEnabled ? data.maxSelectCount : undefined,
+        isOther: isObjective ? data.isOtherInputEnabled : undefined,
+        options: isObjective ? data.choices.map((c) => ({ content: c.name })) : undefined,
+      } satisfies FiveSecondCreateRequest;
+    }
+
+    default:
+      return null;
+  }
+}
+
+export function useSubmitTest() {
+  const navigate = useNavigate();
+  const form = useTestCreateForm();
+  const { openToast } = useToast();
+
+  return useMutation({
+    mutationFn: async () => {
+      let imageKeys: string[] = [];
+      try {
+        imageKeys = (
+          await Promise.all(form.images.map((img) => uploadBase64(img)))
+        ).filter((k): k is string => !!k);
+      } catch (e) {
+        throw new Error(`[테스트 이미지 업로드 실패] ${e instanceof Error ? e.message : String(e)}`);
+      }
+
+      let testId: number;
+      try {
+        const testResponse = await createTest({
+          title: form.name,
+          description: form.summary,
+          categories: form.categories.map((c) => CATEGORY_MAP[c]),
+          serviceName: form.serviceName || undefined,
+          serviceDescription: form.description || undefined,
+          imageKeys,
+        });
+        const id = testResponse.data.data?.id;
+        if (!id) throw new Error("테스트 ID를 받지 못했습니다.");
+        testId = id;
+      } catch (e) {
+        throw new Error(`[테스트 생성 실패] ${e instanceof Error ? e.message : String(e)}`);
+      }
+
+      let mappedQuestions: QuestionRequestItem[] = [];
+      try {
+        mappedQuestions = (
+          await Promise.all(form.questions.map(mapQuestion))
+        ).filter((q): q is QuestionRequestItem => q !== null);
+      } catch (e) {
+        throw new Error(`[질문 이미지 업로드 실패] ${e instanceof Error ? e.message : String(e)}`);
+      }
+
+      if (mappedQuestions.length > 0) {
+        try {
+          await createQuestions(testId, { questions: mappedQuestions });
+        } catch (e) {
+          throw new Error(`[질문 등록 실패] ${e instanceof Error ? e.message : String(e)}`);
+        }
+      }
+
+      return testId;
+    },
+    onSuccess: (testId) => {
+      form.reset();
+      navigate({ to: ROUTES.TEST_DETAIL, params: { testId: String(testId) } });
+    },
+    onError: async (error) => {
+      let message = `실패: ${String(error)}`;
+      if (error instanceof HTTPError) {
+        try {
+          const body = await error.response.json();
+          message = `${error.response.status} ${body?.code ?? ""} ${body?.message ?? ""}`.trim();
+        } catch {
+          message = `HTTP ${error.response.status}`;
+        }
+      }
+      openToast(message, { type: "bottom" });
+    },
+  });
+}

--- a/src/features/test-create/ui/TestCreateFunnel.tsx
+++ b/src/features/test-create/ui/TestCreateFunnel.tsx
@@ -16,6 +16,7 @@ import { ServiceDescriptionEditPage } from "./ServiceDescriptionEditPage";
 import { TestImageEditPage } from "./TestImageEditPage";
 import { useFunnel } from "../model/useFunnel";
 import { useTestCreateForm } from "../model/useTestCreateForm";
+import { useSubmitTest } from "../model/useSubmitTest";
 import type { BasicSubStep, EditPhase, QuestionTypeId } from "../model/types";
 import { ROUTES } from "@/shared/constants/routes";
 import { MultipleCreatePage } from "@/features/question-multiple/create";
@@ -30,6 +31,7 @@ export function TestCreateFunnel() {
   const navigate = useNavigate();
   const funnel = useFunnel();
   const form = useTestCreateForm();
+  const submitTest = useSubmitTest();
   const [basicSubStep, setBasicSubStep] = useState<BasicSubStep>("name");
   const [registerTab, setRegisterTab] = useState<RegisterTab>("questions");
   const [isFocused, setIsFocused] = useState(false);
@@ -195,9 +197,7 @@ export function TestCreateFunnel() {
             funnel.prev();
           }
         }}
-        onSubmit={() => {
-          // TODO: 테스트 만들기 제출
-        }}
+        onSubmit={() => submitTest.mutate()}
         currentStep={funnel.step}
         ctaMode={ctaMode}
         isConfirmDisabled={isConfirmDisabled}
@@ -215,8 +215,8 @@ export function TestCreateFunnel() {
               ? "이전"
               : "취소"
         }
-        isSubmitDisabled
-        submitLabel="테스트 만들기"
+        isSubmitDisabled={submitTest.isPending || !isAllComplete || !form.questions.some((q) => !!q.data)}
+        submitLabel={submitTest.isPending ? "등록 중..." : "테스트 만들기"}
       >
         {funnel.step === "register" ? (
           <TestRegisterStep

--- a/src/shared/api/generated/answer.ts
+++ b/src/shared/api/generated/answer.ts
@@ -95,6 +95,8 @@ export interface ApiResponseAnswerBatchCreateResponse {
   data?: AnswerBatchCreateResponse;
 }
 
+type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
+
 export type createAnswersResponse200 = {
   data: ApiResponseAnswerBatchCreateResponse;
   status: 200;
@@ -144,13 +146,13 @@ export const getCreateAnswersQueryKey = (testId: number, answerCreateRequest?: A
 export const getCreateAnswersQueryOptions = <TData = Awaited<ReturnType<typeof createAnswers>>, TError = ErrorType<unknown>>(
   testId: number,
   answerCreateRequest: AnswerCreateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createAnswers>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createAnswers>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
 ) => {
-  const { query: queryOptions } = options ?? {};
+  const { query: queryOptions, request: requestOptions } = options ?? {};
 
   const queryKey = queryOptions?.queryKey ?? getCreateAnswersQueryKey(testId, answerCreateRequest);
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof createAnswers>>> = ({ signal }) => createAnswers(testId, answerCreateRequest, { signal });
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof createAnswers>>> = ({ signal }) => createAnswers(testId, answerCreateRequest, { signal, ...requestOptions });
 
   return { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof createAnswers>>, TError, TData> & {
     queryKey: DataTag<QueryKey, TData, TError>;
@@ -166,6 +168,7 @@ export function useCreateAnswers<TData = Awaited<ReturnType<typeof createAnswers
   options: {
     query: Partial<UseQueryOptions<Awaited<ReturnType<typeof createAnswers>>, TError, TData>> &
       Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof createAnswers>>, TError, Awaited<ReturnType<typeof createAnswers>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
@@ -175,13 +178,14 @@ export function useCreateAnswers<TData = Awaited<ReturnType<typeof createAnswers
   options?: {
     query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createAnswers>>, TError, TData>> &
       Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof createAnswers>>, TError, Awaited<ReturnType<typeof createAnswers>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 export function useCreateAnswers<TData = Awaited<ReturnType<typeof createAnswers>>, TError = ErrorType<unknown>>(
   testId: number,
   answerCreateRequest: AnswerCreateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createAnswers>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createAnswers>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 /**
@@ -191,7 +195,7 @@ export function useCreateAnswers<TData = Awaited<ReturnType<typeof createAnswers
 export function useCreateAnswers<TData = Awaited<ReturnType<typeof createAnswers>>, TError = ErrorType<unknown>>(
   testId: number,
   answerCreateRequest: AnswerCreateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createAnswers>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createAnswers>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getCreateAnswersQueryOptions(testId, answerCreateRequest, options);

--- a/src/shared/api/generated/auth.ts
+++ b/src/shared/api/generated/auth.ts
@@ -112,6 +112,8 @@ export type HandleTossUnlinkCallbackGetParams = {
   referrer: string;
 };
 
+type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
+
 export type unlinkTossResponse200 = {
   data: ApiResponseVoid;
   status: 200;
@@ -143,12 +145,13 @@ export const getUnlinkTossQueryKey = () => {
 
 export const getUnlinkTossQueryOptions = <TData = Awaited<ReturnType<typeof unlinkToss>>, TError = ErrorType<unknown>>(options?: {
   query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkToss>>, TError, TData>>;
+  request?: SecondParameter<typeof kyMutator>;
 }) => {
-  const { query: queryOptions } = options ?? {};
+  const { query: queryOptions, request: requestOptions } = options ?? {};
 
   const queryKey = queryOptions?.queryKey ?? getUnlinkTossQueryKey();
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof unlinkToss>>> = ({ signal }) => unlinkToss({ signal });
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof unlinkToss>>> = ({ signal }) => unlinkToss({ signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof unlinkToss>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> };
 };
@@ -160,6 +163,7 @@ export function useUnlinkToss<TData = Awaited<ReturnType<typeof unlinkToss>>, TE
   options: {
     query: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkToss>>, TError, TData>> &
       Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof unlinkToss>>, TError, Awaited<ReturnType<typeof unlinkToss>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
@@ -167,11 +171,12 @@ export function useUnlinkToss<TData = Awaited<ReturnType<typeof unlinkToss>>, TE
   options?: {
     query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkToss>>, TError, TData>> &
       Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof unlinkToss>>, TError, Awaited<ReturnType<typeof unlinkToss>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 export function useUnlinkToss<TData = Awaited<ReturnType<typeof unlinkToss>>, TError = ErrorType<unknown>>(
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkToss>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkToss>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 /**
@@ -179,7 +184,7 @@ export function useUnlinkToss<TData = Awaited<ReturnType<typeof unlinkToss>>, TE
  */
 
 export function useUnlinkToss<TData = Awaited<ReturnType<typeof unlinkToss>>, TError = ErrorType<unknown>>(
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkToss>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkToss>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getUnlinkTossQueryOptions(options);
@@ -222,13 +227,13 @@ export const getUnlinkTossByUserKeyQueryKey = (tossUnlinkByUserKeyRequest?: Toss
 
 export const getUnlinkTossByUserKeyQueryOptions = <TData = Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError = ErrorType<unknown>>(
   tossUnlinkByUserKeyRequest: TossUnlinkByUserKeyRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
 ) => {
-  const { query: queryOptions } = options ?? {};
+  const { query: queryOptions, request: requestOptions } = options ?? {};
 
   const queryKey = queryOptions?.queryKey ?? getUnlinkTossByUserKeyQueryKey(tossUnlinkByUserKeyRequest);
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof unlinkTossByUserKey>>> = ({ signal }) => unlinkTossByUserKey(tossUnlinkByUserKeyRequest, { signal });
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof unlinkTossByUserKey>>> = ({ signal }) => unlinkTossByUserKey(tossUnlinkByUserKeyRequest, { signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> };
 };
@@ -241,6 +246,7 @@ export function useUnlinkTossByUserKey<TData = Awaited<ReturnType<typeof unlinkT
   options: {
     query: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, TData>> &
       Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, Awaited<ReturnType<typeof unlinkTossByUserKey>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
@@ -249,12 +255,13 @@ export function useUnlinkTossByUserKey<TData = Awaited<ReturnType<typeof unlinkT
   options?: {
     query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, TData>> &
       Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, Awaited<ReturnType<typeof unlinkTossByUserKey>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 export function useUnlinkTossByUserKey<TData = Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError = ErrorType<unknown>>(
   tossUnlinkByUserKeyRequest: TossUnlinkByUserKeyRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 /**
@@ -263,7 +270,7 @@ export function useUnlinkTossByUserKey<TData = Awaited<ReturnType<typeof unlinkT
 
 export function useUnlinkTossByUserKey<TData = Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError = ErrorType<unknown>>(
   tossUnlinkByUserKeyRequest: TossUnlinkByUserKeyRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlinkTossByUserKey>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getUnlinkTossByUserKeyQueryOptions(tossUnlinkByUserKeyRequest, options);
@@ -306,13 +313,13 @@ export const getLoginWithTossQueryKey = (tossLoginRequest?: TossLoginRequest) =>
 
 export const getLoginWithTossQueryOptions = <TData = Awaited<ReturnType<typeof loginWithToss>>, TError = ErrorType<unknown>>(
   tossLoginRequest: TossLoginRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
 ) => {
-  const { query: queryOptions } = options ?? {};
+  const { query: queryOptions, request: requestOptions } = options ?? {};
 
   const queryKey = queryOptions?.queryKey ?? getLoginWithTossQueryKey(tossLoginRequest);
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof loginWithToss>>> = ({ signal }) => loginWithToss(tossLoginRequest, { signal });
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof loginWithToss>>> = ({ signal }) => loginWithToss(tossLoginRequest, { signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> };
 };
@@ -325,6 +332,7 @@ export function useLoginWithToss<TData = Awaited<ReturnType<typeof loginWithToss
   options: {
     query: Partial<UseQueryOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, TData>> &
       Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, Awaited<ReturnType<typeof loginWithToss>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
@@ -333,12 +341,13 @@ export function useLoginWithToss<TData = Awaited<ReturnType<typeof loginWithToss
   options?: {
     query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, TData>> &
       Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, Awaited<ReturnType<typeof loginWithToss>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 export function useLoginWithToss<TData = Awaited<ReturnType<typeof loginWithToss>>, TError = ErrorType<unknown>>(
   tossLoginRequest: TossLoginRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 /**
@@ -347,7 +356,7 @@ export function useLoginWithToss<TData = Awaited<ReturnType<typeof loginWithToss
 
 export function useLoginWithToss<TData = Awaited<ReturnType<typeof loginWithToss>>, TError = ErrorType<unknown>>(
   tossLoginRequest: TossLoginRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof loginWithToss>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getLoginWithTossQueryOptions(tossLoginRequest, options);
@@ -394,18 +403,19 @@ export const handleTossUnlinkCallbackGet = async (params: HandleTossUnlinkCallba
 
 export const getHandleTossUnlinkCallbackGetMutationOptions = <TError = ErrorType<unknown>, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackGet>>, TError, { params: HandleTossUnlinkCallbackGetParams }, TContext>;
+  request?: SecondParameter<typeof kyMutator>;
 }): UseMutationOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackGet>>, TError, { params: HandleTossUnlinkCallbackGetParams }, TContext> => {
   const mutationKey = ["handleTossUnlinkCallbackGet"];
-  const { mutation: mutationOptions } = options
+  const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
       ? options
       : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey } };
+    : { mutation: { mutationKey }, request: undefined };
 
   const mutationFn: MutationFunction<Awaited<ReturnType<typeof handleTossUnlinkCallbackGet>>, { params: HandleTossUnlinkCallbackGetParams }> = (props) => {
     const { params } = props ?? {};
 
-    return handleTossUnlinkCallbackGet(params);
+    return handleTossUnlinkCallbackGet(params, requestOptions);
   };
 
   return { mutationFn, ...mutationOptions };
@@ -419,7 +429,10 @@ export type HandleTossUnlinkCallbackGetMutationError = ErrorType<unknown>;
  * @summary 🙅🏻‍♀️ 토스 연결 해제 콜백
  */
 export const useHandleTossUnlinkCallbackGet = <TError = ErrorType<unknown>, TContext = unknown>(
-  options?: { mutation?: UseMutationOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackGet>>, TError, { params: HandleTossUnlinkCallbackGetParams }, TContext> },
+  options?: {
+    mutation?: UseMutationOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackGet>>, TError, { params: HandleTossUnlinkCallbackGetParams }, TContext>;
+    request?: SecondParameter<typeof kyMutator>;
+  },
   queryClient?: QueryClient,
 ): UseMutationResult<Awaited<ReturnType<typeof handleTossUnlinkCallbackGet>>, TError, { params: HandleTossUnlinkCallbackGetParams }, TContext> => {
   return useMutation(getHandleTossUnlinkCallbackGetMutationOptions(options), queryClient);
@@ -458,13 +471,13 @@ export const getHandleTossUnlinkCallbackPostQueryKey = (tossUnlinkCallbackReques
 
 export const getHandleTossUnlinkCallbackPostQueryOptions = <TData = Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError = ErrorType<unknown>>(
   tossUnlinkCallbackRequest: TossUnlinkCallbackRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
 ) => {
-  const { query: queryOptions } = options ?? {};
+  const { query: queryOptions, request: requestOptions } = options ?? {};
 
   const queryKey = queryOptions?.queryKey ?? getHandleTossUnlinkCallbackPostQueryKey(tossUnlinkCallbackRequest);
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>> = ({ signal }) => handleTossUnlinkCallbackPost(tossUnlinkCallbackRequest, { signal });
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>> = ({ signal }) => handleTossUnlinkCallbackPost(tossUnlinkCallbackRequest, { signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> };
 };
@@ -477,6 +490,7 @@ export function useHandleTossUnlinkCallbackPost<TData = Awaited<ReturnType<typeo
   options: {
     query: Partial<UseQueryOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, TData>> &
       Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
@@ -485,12 +499,13 @@ export function useHandleTossUnlinkCallbackPost<TData = Awaited<ReturnType<typeo
   options?: {
     query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, TData>> &
       Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 export function useHandleTossUnlinkCallbackPost<TData = Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError = ErrorType<unknown>>(
   tossUnlinkCallbackRequest: TossUnlinkCallbackRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 /**
@@ -499,7 +514,7 @@ export function useHandleTossUnlinkCallbackPost<TData = Awaited<ReturnType<typeo
 
 export function useHandleTossUnlinkCallbackPost<TData = Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError = ErrorType<unknown>>(
   tossUnlinkCallbackRequest: TossUnlinkCallbackRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof handleTossUnlinkCallbackPost>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getHandleTossUnlinkCallbackPostQueryOptions(tossUnlinkCallbackRequest, options);
@@ -542,13 +557,13 @@ export const getReissueQueryKey = (authReissueRequest?: AuthReissueRequest) => {
 
 export const getReissueQueryOptions = <TData = Awaited<ReturnType<typeof reissue>>, TError = ErrorType<unknown>>(
   authReissueRequest: AuthReissueRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof reissue>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof reissue>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
 ) => {
-  const { query: queryOptions } = options ?? {};
+  const { query: queryOptions, request: requestOptions } = options ?? {};
 
   const queryKey = queryOptions?.queryKey ?? getReissueQueryKey(authReissueRequest);
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof reissue>>> = ({ signal }) => reissue(authReissueRequest, { signal });
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof reissue>>> = ({ signal }) => reissue(authReissueRequest, { signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof reissue>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> };
 };
@@ -561,6 +576,7 @@ export function useReissue<TData = Awaited<ReturnType<typeof reissue>>, TError =
   options: {
     query: Partial<UseQueryOptions<Awaited<ReturnType<typeof reissue>>, TError, TData>> &
       Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof reissue>>, TError, Awaited<ReturnType<typeof reissue>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
@@ -569,12 +585,13 @@ export function useReissue<TData = Awaited<ReturnType<typeof reissue>>, TError =
   options?: {
     query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof reissue>>, TError, TData>> &
       Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof reissue>>, TError, Awaited<ReturnType<typeof reissue>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 export function useReissue<TData = Awaited<ReturnType<typeof reissue>>, TError = ErrorType<unknown>>(
   authReissueRequest: AuthReissueRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof reissue>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof reissue>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 /**
@@ -583,7 +600,7 @@ export function useReissue<TData = Awaited<ReturnType<typeof reissue>>, TError =
 
 export function useReissue<TData = Awaited<ReturnType<typeof reissue>>, TError = ErrorType<unknown>>(
   authReissueRequest: AuthReissueRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof reissue>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof reissue>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getReissueQueryOptions(authReissueRequest, options);
@@ -624,12 +641,13 @@ export const getLogoutQueryKey = () => {
 
 export const getLogoutQueryOptions = <TData = Awaited<ReturnType<typeof logout>>, TError = ErrorType<unknown>>(options?: {
   query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof logout>>, TError, TData>>;
+  request?: SecondParameter<typeof kyMutator>;
 }) => {
-  const { query: queryOptions } = options ?? {};
+  const { query: queryOptions, request: requestOptions } = options ?? {};
 
   const queryKey = queryOptions?.queryKey ?? getLogoutQueryKey();
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof logout>>> = ({ signal }) => logout({ signal });
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof logout>>> = ({ signal }) => logout({ signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof logout>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> };
 };
@@ -641,6 +659,7 @@ export function useLogout<TData = Awaited<ReturnType<typeof logout>>, TError = E
   options: {
     query: Partial<UseQueryOptions<Awaited<ReturnType<typeof logout>>, TError, TData>> &
       Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof logout>>, TError, Awaited<ReturnType<typeof logout>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
@@ -648,11 +667,12 @@ export function useLogout<TData = Awaited<ReturnType<typeof logout>>, TError = E
   options?: {
     query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof logout>>, TError, TData>> &
       Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof logout>>, TError, Awaited<ReturnType<typeof logout>>>, "initialData">;
+    request?: SecondParameter<typeof kyMutator>;
   },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 export function useLogout<TData = Awaited<ReturnType<typeof logout>>, TError = ErrorType<unknown>>(
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof logout>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof logout>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 /**
@@ -660,7 +680,7 @@ export function useLogout<TData = Awaited<ReturnType<typeof logout>>, TError = E
  */
 
 export function useLogout<TData = Awaited<ReturnType<typeof logout>>, TError = ErrorType<unknown>>(
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof logout>>, TError, TData>> },
+  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof logout>>, TError, TData>>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
   const queryOptions = getLogoutQueryOptions(options);
@@ -703,16 +723,17 @@ export const getTossIntegrationStatus = async (options?: RequestInit): Promise<g
 
 export const getGetTossIntegrationStatusMutationOptions = <TError = ErrorType<unknown>, TContext = unknown>(options?: {
   mutation?: UseMutationOptions<Awaited<ReturnType<typeof getTossIntegrationStatus>>, TError, void, TContext>;
+  request?: SecondParameter<typeof kyMutator>;
 }): UseMutationOptions<Awaited<ReturnType<typeof getTossIntegrationStatus>>, TError, void, TContext> => {
   const mutationKey = ["getTossIntegrationStatus"];
-  const { mutation: mutationOptions } = options
+  const { mutation: mutationOptions, request: requestOptions } = options
     ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
       ? options
       : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey } };
+    : { mutation: { mutationKey }, request: undefined };
 
   const mutationFn: MutationFunction<Awaited<ReturnType<typeof getTossIntegrationStatus>>, void> = () => {
-    return getTossIntegrationStatus();
+    return getTossIntegrationStatus(requestOptions);
   };
 
   return { mutationFn, ...mutationOptions };
@@ -726,7 +747,7 @@ export type GetTossIntegrationStatusMutationError = ErrorType<unknown>;
  * @summary 토스 연동 상태 조회
  */
 export const useGetTossIntegrationStatus = <TError = ErrorType<unknown>, TContext = unknown>(
-  options?: { mutation?: UseMutationOptions<Awaited<ReturnType<typeof getTossIntegrationStatus>>, TError, void, TContext> },
+  options?: { mutation?: UseMutationOptions<Awaited<ReturnType<typeof getTossIntegrationStatus>>, TError, void, TContext>; request?: SecondParameter<typeof kyMutator> },
   queryClient?: QueryClient,
 ): UseMutationResult<Awaited<ReturnType<typeof getTossIntegrationStatus>>, TError, void, TContext> => {
   return useMutation(getGetTossIntegrationStatusMutationOptions(options), queryClient);

--- a/src/shared/api/generated/file.ts
+++ b/src/shared/api/generated/file.ts
@@ -5,7 +5,10 @@
  * MATE 서버 API 문서
  * OpenAPI spec version: v1.0.0
  */
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery
+} from '@tanstack/react-query';
 import type {
   DataTag,
   DefinedInitialDataOptions,
@@ -18,11 +21,11 @@ import type {
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
-  UseQueryResult,
-} from "@tanstack/react-query";
+  UseQueryResult
+} from '@tanstack/react-query';
 
-import { kyMutator } from "../mutator";
-import type { ErrorType } from "../mutator";
+import { kyMutator } from '../mutator';
+import type { ErrorType } from '../mutator';
 export interface UploadUrlResponse {
   presignedUrl?: string;
   fileKey?: string;
@@ -47,42 +50,49 @@ export interface ApiResponseDownloadUrlResponse {
 }
 
 export type GenerateUploadUrlParams = {
-  /**
-   * 파일 확장자 (점 없이 입력, 예: jpg, pdf)
-   */
-  extension: string;
+/**
+ * 파일 확장자 (점 없이 입력, 예: jpg, pdf)
+ */
+extension: string;
 };
 
 export type GenerateDownloadUrlParams = {
-  /**
-   * 업로드 시 발급받은 fileKey
-   */
-  fileKey: string;
+/**
+ * 업로드 시 발급받은 fileKey
+ */
+fileKey: string;
 };
+
+type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
+
+
 
 export type generateUploadUrlResponse200 = {
-  data: ApiResponseUploadUrlResponse;
-  status: 200;
-};
+  data: ApiResponseUploadUrlResponse
+  status: 200
+}
 
-export type generateUploadUrlResponseSuccess = generateUploadUrlResponse200 & {
+export type generateUploadUrlResponseSuccess = (generateUploadUrlResponse200) & {
   headers: Headers;
 };
-export type generateUploadUrlResponse = generateUploadUrlResponseSuccess;
+;
 
-export const getGenerateUploadUrlUrl = (params: GenerateUploadUrlParams) => {
+export type generateUploadUrlResponse = (generateUploadUrlResponseSuccess)
+
+export const getGenerateUploadUrlUrl = (params: GenerateUploadUrlParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
+
     if (value !== undefined) {
-      normalizedParams.append(key, value === null ? "null" : value.toString());
+      normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
   });
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/api/v1/files/presigned-url/upload?${stringifiedParams}` : `/api/v1/files/presigned-url/upload`;
-};
+  return stringifiedParams.length > 0 ? `/api/v1/files/presigned-url/upload?${stringifiedParams}` : `/api/v1/files/presigned-url/upload`
+}
 
 /**
  * 파일 업로드용 Presigned URL을 발급합니다. 클라이언트는 서버를 경유하지 않고 Azure Blob Storage에 직접 업로드합니다.
@@ -108,92 +118,121 @@ export const getGenerateUploadUrlUrl = (params: GenerateUploadUrlParams) => {
  * @summary 파일 업로드 URL 발급
  */
 export const generateUploadUrl = async (params: GenerateUploadUrlParams, options?: RequestInit): Promise<generateUploadUrlResponse> => {
-  return kyMutator<generateUploadUrlResponse>(getGenerateUploadUrlUrl(params), {
+
+  return kyMutator<generateUploadUrlResponse>(getGenerateUploadUrlUrl(params),
+  {
     ...options,
-    method: "POST",
-  });
-};
+    method: 'POST'
 
-export const getGenerateUploadUrlQueryKey = (params?: GenerateUploadUrlParams) => {
-  return ["POST", `/api/v1/files/presigned-url/upload`, ...(params ? [params] : [])] as const;
-};
 
-export const getGenerateUploadUrlQueryOptions = <TData = Awaited<ReturnType<typeof generateUploadUrl>>, TError = ErrorType<unknown>>(
-  params: GenerateUploadUrlParams,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData>> },
+  }
+);}
+
+
+
+
+
+export const getGenerateUploadUrlQueryKey = (params?: GenerateUploadUrlParams,) => {
+    return [
+    'POST', `/api/v1/files/presigned-url/upload`, ...(params ? [params] : [])
+    ] as const;
+    }
+
+
+export const getGenerateUploadUrlQueryOptions = <TData = Awaited<ReturnType<typeof generateUploadUrl>>, TError = ErrorType<unknown>>(params: GenerateUploadUrlParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
 ) => {
-  const { query: queryOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getGenerateUploadUrlQueryKey(params);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof generateUploadUrl>>> = ({ signal }) => generateUploadUrl(params, { signal });
+  const queryKey =  queryOptions?.queryKey ?? getGenerateUploadUrlQueryKey(params);
 
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> };
-};
 
-export type GenerateUploadUrlQueryResult = NonNullable<Awaited<ReturnType<typeof generateUploadUrl>>>;
-export type GenerateUploadUrlQueryError = ErrorType<unknown>;
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof generateUploadUrl>>> = ({ signal }) => generateUploadUrl(params, { signal, ...requestOptions });
+
+
+
+
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type GenerateUploadUrlQueryResult = NonNullable<Awaited<ReturnType<typeof generateUploadUrl>>>
+export type GenerateUploadUrlQueryError = ErrorType<unknown>
+
 
 export function useGenerateUploadUrl<TData = Awaited<ReturnType<typeof generateUploadUrl>>, TError = ErrorType<unknown>>(
-  params: GenerateUploadUrlParams,
-  options: {
-    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData>> &
-      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, Awaited<ReturnType<typeof generateUploadUrl>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ params: GenerateUploadUrlParams, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof generateUploadUrl>>,
+          TError,
+          Awaited<ReturnType<typeof generateUploadUrl>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useGenerateUploadUrl<TData = Awaited<ReturnType<typeof generateUploadUrl>>, TError = ErrorType<unknown>>(
-  params: GenerateUploadUrlParams,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData>> &
-      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, Awaited<ReturnType<typeof generateUploadUrl>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ params: GenerateUploadUrlParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof generateUploadUrl>>,
+          TError,
+          Awaited<ReturnType<typeof generateUploadUrl>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useGenerateUploadUrl<TData = Awaited<ReturnType<typeof generateUploadUrl>>, TError = ErrorType<unknown>>(
-  params: GenerateUploadUrlParams,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ params: GenerateUploadUrlParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
  * @summary 파일 업로드 URL 발급
  */
 
 export function useGenerateUploadUrl<TData = Awaited<ReturnType<typeof generateUploadUrl>>, TError = ErrorType<unknown>>(
-  params: GenerateUploadUrlParams,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getGenerateUploadUrlQueryOptions(params, options);
+ params: GenerateUploadUrlParams, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof generateUploadUrl>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+  const queryOptions = getGenerateUploadUrlQueryOptions(params,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-export type generateDownloadUrlResponse200 = {
-  data: ApiResponseDownloadUrlResponse;
-  status: 200;
-};
 
-export type generateDownloadUrlResponseSuccess = generateDownloadUrlResponse200 & {
+
+
+
+
+
+export type generateDownloadUrlResponse200 = {
+  data: ApiResponseDownloadUrlResponse
+  status: 200
+}
+
+export type generateDownloadUrlResponseSuccess = (generateDownloadUrlResponse200) & {
   headers: Headers;
 };
-export type generateDownloadUrlResponse = generateDownloadUrlResponseSuccess;
+;
 
-export const getGenerateDownloadUrlUrl = (params: GenerateDownloadUrlParams) => {
+export type generateDownloadUrlResponse = (generateDownloadUrlResponseSuccess)
+
+export const getGenerateDownloadUrlUrl = (params: GenerateDownloadUrlParams,) => {
   const normalizedParams = new URLSearchParams();
 
   Object.entries(params || {}).forEach(([key, value]) => {
+
     if (value !== undefined) {
-      normalizedParams.append(key, value === null ? "null" : value.toString());
+      normalizedParams.append(key, value === null ? 'null' : value.toString())
     }
   });
 
   const stringifiedParams = normalizedParams.toString();
 
-  return stringifiedParams.length > 0 ? `/api/v1/files/presigned-url/download?${stringifiedParams}` : `/api/v1/files/presigned-url/download`;
-};
+  return stringifiedParams.length > 0 ? `/api/v1/files/presigned-url/download?${stringifiedParams}` : `/api/v1/files/presigned-url/download`
+}
 
 /**
  * 저장된 파일의 다운로드용 Presigned URL을 발급합니다.
@@ -208,41 +247,60 @@ export const getGenerateDownloadUrlUrl = (params: GenerateDownloadUrlParams) => 
  * @summary 파일 다운로드 URL 발급
  */
 export const generateDownloadUrl = async (params: GenerateDownloadUrlParams, options?: RequestInit): Promise<generateDownloadUrlResponse> => {
-  return kyMutator<generateDownloadUrlResponse>(getGenerateDownloadUrlUrl(params), {
+
+  return kyMutator<generateDownloadUrlResponse>(getGenerateDownloadUrlUrl(params),
+  {
     ...options,
-    method: "GET",
-  });
-};
+    method: 'GET'
 
-export const getGenerateDownloadUrlMutationOptions = <TError = ErrorType<unknown>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<Awaited<ReturnType<typeof generateDownloadUrl>>, TError, { params: GenerateDownloadUrlParams }, TContext>;
-}): UseMutationOptions<Awaited<ReturnType<typeof generateDownloadUrl>>, TError, { params: GenerateDownloadUrlParams }, TContext> => {
-  const mutationKey = ["generateDownloadUrl"];
-  const { mutation: mutationOptions } = options
-    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey } };
 
-  const mutationFn: MutationFunction<Awaited<ReturnType<typeof generateDownloadUrl>>, { params: GenerateDownloadUrlParams }> = (props) => {
-    const { params } = props ?? {};
+  }
+);}
 
-    return generateDownloadUrl(params);
-  };
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type GenerateDownloadUrlMutationResult = NonNullable<Awaited<ReturnType<typeof generateDownloadUrl>>>;
 
-export type GenerateDownloadUrlMutationError = ErrorType<unknown>;
+export const getGenerateDownloadUrlMutationOptions = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof generateDownloadUrl>>, TError,{params: GenerateDownloadUrlParams}, TContext>, request?: SecondParameter<typeof kyMutator>}
+): UseMutationOptions<Awaited<ReturnType<typeof generateDownloadUrl>>, TError,{params: GenerateDownloadUrlParams}, TContext> => {
 
-/**
+const mutationKey = ['generateDownloadUrl'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof generateDownloadUrl>>, {params: GenerateDownloadUrlParams}> = (props) => {
+          const {params} = props ?? {};
+
+          return  generateDownloadUrl(params,requestOptions)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type GenerateDownloadUrlMutationResult = NonNullable<Awaited<ReturnType<typeof generateDownloadUrl>>>
+
+    export type GenerateDownloadUrlMutationError = ErrorType<unknown>
+
+    /**
  * @summary 파일 다운로드 URL 발급
  */
-export const useGenerateDownloadUrl = <TError = ErrorType<unknown>, TContext = unknown>(
-  options?: { mutation?: UseMutationOptions<Awaited<ReturnType<typeof generateDownloadUrl>>, TError, { params: GenerateDownloadUrlParams }, TContext> },
-  queryClient?: QueryClient,
-): UseMutationResult<Awaited<ReturnType<typeof generateDownloadUrl>>, TError, { params: GenerateDownloadUrlParams }, TContext> => {
-  return useMutation(getGenerateDownloadUrlMutationOptions(options), queryClient);
-};
+export const useGenerateDownloadUrl = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof generateDownloadUrl>>, TError,{params: GenerateDownloadUrlParams}, TContext>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof generateDownloadUrl>>,
+        TError,
+        {params: GenerateDownloadUrlParams},
+        TContext
+      > => {
+      return useMutation(getGenerateDownloadUrlMutationOptions(options), queryClient);
+    }

--- a/src/shared/api/generated/question.ts
+++ b/src/shared/api/generated/question.ts
@@ -5,7 +5,10 @@
  * MATE 서버 API 문서
  * OpenAPI spec version: v1.0.0
  */
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery
+} from '@tanstack/react-query';
 import type {
   DataTag,
   DefinedInitialDataOptions,
@@ -18,33 +21,34 @@ import type {
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
-  UseQueryResult,
-} from "@tanstack/react-query";
+  UseQueryResult
+} from '@tanstack/react-query';
 
-import { kyMutator } from "../mutator";
-import type { ErrorType } from "../mutator";
+import { kyMutator } from '../mutator';
+import type { ErrorType } from '../mutator';
 export interface QuestionCreateItem {
   type: string;
 }
 
-export type AbTestCreateRequestImageRatio = (typeof AbTestCreateRequestImageRatio)[keyof typeof AbTestCreateRequestImageRatio];
+export type AbTestCreateRequestImageRatio = typeof AbTestCreateRequestImageRatio[keyof typeof AbTestCreateRequestImageRatio];
+
 
 export const AbTestCreateRequestImageRatio = {
-  "9:16": "9:16",
-  "1:1": "1:1",
-  "4:3": "4:3",
+  '9:16': '9:16',
+  '1:1': '1:1',
+  '4:3': '4:3',
 } as const;
 
 export type AbTestCreateRequest = QuestionCreateItem & {
   /**
-   * @minLength 0
-   * @maxLength 34
-   */
+     * @minLength 0
+     * @maxLength 34
+     */
   title?: string;
   /**
-   * @minLength 0
-   * @maxLength 50
-   */
+     * @minLength 0
+     * @maxLength 50
+     */
   description?: string;
   /** @minLength 1 */
   aImageKey?: string;
@@ -58,47 +62,48 @@ export type CardSortingCreateRequest = QuestionCreateItem & {
   title?: string;
   description?: string;
   /**
-   * @minItems 4
-   * @maxItems 12
-   * @items.minLength 0
-   * @items.maxLength 16
-   */
+     * @minItems 4
+     * @maxItems 12
+     * @items.minLength 0
+     * @items.maxLength 16
+     */
   cards: string[];
   /**
-   * @minItems 1
-   * @maxItems 3
-   * @items.minLength 0
-   * @items.maxLength 12
-   */
+     * @minItems 1
+     * @maxItems 3
+     * @items.minLength 0
+     * @items.maxLength 12
+     */
   categories: string[];
 };
 
-export type FiveSecondCreateRequestImageRatio = (typeof FiveSecondCreateRequestImageRatio)[keyof typeof FiveSecondCreateRequestImageRatio];
+export type FiveSecondCreateRequestImageRatio = typeof FiveSecondCreateRequestImageRatio[keyof typeof FiveSecondCreateRequestImageRatio];
+
 
 export const FiveSecondCreateRequestImageRatio = {
-  "9:16": "9:16",
-  "1:1": "1:1",
-  "4:3": "4:3",
+  '9:16': '9:16',
+  '1:1': '1:1',
+  '4:3': '4:3',
 } as const;
 
 export interface FiveSecondOptionRequest {
   /**
-   * @minLength 0
-   * @maxLength 50
-   */
+     * @minLength 0
+     * @maxLength 50
+     */
   content?: string;
 }
 
 export type FiveSecondCreateRequest = QuestionCreateItem & {
   /**
-   * @minLength 0
-   * @maxLength 34
-   */
+     * @minLength 0
+     * @maxLength 34
+     */
   title?: string;
   /**
-   * @minLength 0
-   * @maxLength 50
-   */
+     * @minLength 0
+     * @maxLength 50
+     */
   description?: string;
   /** @minLength 1 */
   imageKey?: string;
@@ -113,46 +118,47 @@ export type FiveSecondCreateRequest = QuestionCreateItem & {
   /** 객관식일 때만 필수입니다. 주관식일 때는 null이어야 합니다. */
   isOther?: boolean;
   /**
-   * 5초 테스트 객관식 선택지
-   * @minItems 0
-   * @maxItems 10
-   */
+     * 5초 테스트 객관식 선택지
+     * @minItems 0
+     * @maxItems 10
+     */
   options?: FiveSecondOptionRequest[];
 };
 
 export interface ObjectiveOptionRequest {
   /**
-   * @minLength 0
-   * @maxLength 17
-   */
+     * @minLength 0
+     * @maxLength 17
+     */
   content?: string;
   imageKey?: string;
 }
 
 export type ObjectiveCreateRequest = QuestionCreateItem & {
   /**
-   * @minLength 0
-   * @maxLength 34
-   */
+     * @minLength 0
+     * @maxLength 34
+     */
   title?: string;
   /**
-   * @minLength 0
-   * @maxLength 55
-   */
+     * @minLength 0
+     * @maxLength 55
+     */
   description?: string;
   isDuplicate: boolean;
   maxSelect?: number;
   minSelect?: number;
   isOther: boolean;
   /**
-   * 객관식 선택지 목록
-   * @minItems 2
-   * @maxItems 2147483647
-   */
+     * 객관식 선택지 목록
+     * @minItems 2
+     * @maxItems 2147483647
+     */
   options: ObjectiveOptionRequest[];
 };
 
-export type ScaleCreateRequestRange = (typeof ScaleCreateRequestRange)[keyof typeof ScaleCreateRequestRange];
+export type ScaleCreateRequestRange = typeof ScaleCreateRequestRange[keyof typeof ScaleCreateRequestRange];
+
 
 export const ScaleCreateRequestRange = {
   NUMBER_5: 5,
@@ -161,39 +167,39 @@ export const ScaleCreateRequestRange = {
 
 export type ScaleCreateRequest = QuestionCreateItem & {
   /**
-   * @minLength 0
-   * @maxLength 34
-   */
+     * @minLength 0
+     * @maxLength 34
+     */
   title?: string;
   /**
-   * @minLength 0
-   * @maxLength 50
-   */
+     * @minLength 0
+     * @maxLength 50
+     */
   description?: string;
   imageKey?: string;
   /**
-   * @minLength 0
-   * @maxLength 100
-   */
+     * @minLength 0
+     * @maxLength 100
+     */
   minLabel?: string;
   /**
-   * @minLength 0
-   * @maxLength 100
-   */
+     * @minLength 0
+     * @maxLength 100
+     */
   maxLabel?: string;
   range: ScaleCreateRequestRange;
 };
 
 export type SubjectiveCreateRequest = QuestionCreateItem & {
   /**
-   * @minLength 0
-   * @maxLength 34
-   */
+     * @minLength 0
+     * @maxLength 34
+     */
   title?: string;
   /**
-   * @minLength 0
-   * @maxLength 55
-   */
+     * @minLength 0
+     * @maxLength 55
+     */
   description?: string;
   imageKey?: string;
 };
@@ -209,10 +215,10 @@ export interface Feature {
   /** @minLength 1 */
   label?: string;
   /**
-   * 하위 노드 목록
-   * @minItems 0
-   * @maxItems 4
-   */
+     * 하위 노드 목록
+     * @minItems 0
+     * @maxItems 4
+     */
   children?: TreeNode[];
 }
 
@@ -221,31 +227,32 @@ export type TreeTestCreateRequest = QuestionCreateItem & {
   title?: string;
   description?: string;
   /**
-   * 트리테스트 루트 기능 목록
-   * @minItems 1
-   * @maxItems 4
-   */
+     * 트리테스트 루트 기능 목록
+     * @minItems 1
+     * @maxItems 4
+     */
   features: Feature[];
 };
 
 export interface QuestionCreateRequest {
   /**
-   * 등록할 질문 문항 목록
-   * @minItems 1
-   */
+     * 등록할 질문 문항 목록
+     * @minItems 1
+     */
   questions?: (AbTestCreateRequest | CardSortingCreateRequest | FiveSecondCreateRequest | ObjectiveCreateRequest | ScaleCreateRequest | SubjectiveCreateRequest | TreeTestCreateRequest)[];
 }
 
-export type QuestionCreateResultType = (typeof QuestionCreateResultType)[keyof typeof QuestionCreateResultType];
+export type QuestionCreateResultType = typeof QuestionCreateResultType[keyof typeof QuestionCreateResultType];
+
 
 export const QuestionCreateResultType = {
-  OBJECTIVE: "OBJECTIVE",
-  SUBJECTIVE: "SUBJECTIVE",
-  FIVE_SECOND: "FIVE_SECOND",
-  SCALE: "SCALE",
-  AB_TEST: "AB_TEST",
-  CARD_SORTING: "CARD_SORTING",
-  TREE_TEST: "TREE_TEST",
+  OBJECTIVE: 'OBJECTIVE',
+  SUBJECTIVE: 'SUBJECTIVE',
+  FIVE_SECOND: 'FIVE_SECOND',
+  SCALE: 'SCALE',
+  AB_TEST: 'AB_TEST',
+  CARD_SORTING: 'CARD_SORTING',
+  TREE_TEST: 'TREE_TEST',
 } as const;
 
 export interface QuestionCreateResult {
@@ -269,16 +276,17 @@ export interface ApiResponseQuestionCreateResponse {
 /**
  * 질문 유형
  */
-export type QuestionSummaryItemType = (typeof QuestionSummaryItemType)[keyof typeof QuestionSummaryItemType];
+export type QuestionSummaryItemType = typeof QuestionSummaryItemType[keyof typeof QuestionSummaryItemType];
+
 
 export const QuestionSummaryItemType = {
-  OBJECTIVE: "OBJECTIVE",
-  SUBJECTIVE: "SUBJECTIVE",
-  FIVE_SECOND: "FIVE_SECOND",
-  SCALE: "SCALE",
-  AB_TEST: "AB_TEST",
-  CARD_SORTING: "CARD_SORTING",
-  TREE_TEST: "TREE_TEST",
+  OBJECTIVE: 'OBJECTIVE',
+  SUBJECTIVE: 'SUBJECTIVE',
+  FIVE_SECOND: 'FIVE_SECOND',
+  SCALE: 'SCALE',
+  AB_TEST: 'AB_TEST',
+  CARD_SORTING: 'CARD_SORTING',
+  TREE_TEST: 'TREE_TEST',
 } as const;
 
 /**
@@ -314,19 +322,29 @@ export interface ApiResponseQuestionSummaryResponse {
   data?: QuestionSummaryResponse;
 }
 
+type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
+
+
+
 export type getQuestionsDetailsResponseDefault = {
-  data: unknown;
-  status: number;
-};
-export type getQuestionsDetailsResponseError = getQuestionsDetailsResponseDefault & {
+  data: unknown
+  status: number
+}
+
+;
+export type getQuestionsDetailsResponseError = (getQuestionsDetailsResponseDefault) & {
   headers: Headers;
 };
 
-export type getQuestionsDetailsResponse = getQuestionsDetailsResponseError;
+export type getQuestionsDetailsResponse = (getQuestionsDetailsResponseError)
 
-export const getGetQuestionsDetailsUrl = (testId: number) => {
-  return `/api/v1/tests/${testId}/questions`;
-};
+export const getGetQuestionsDetailsUrl = (testId: number,) => {
+
+
+
+
+  return `/api/v1/tests/${testId}/questions`
+}
 
 /**
  * testId에 해당한 테스트의 모든 질문 문항을 상세조회합니다. TT01-01 화면에 해당하는 api 입니다.
@@ -338,58 +356,83 @@ export const getGetQuestionsDetailsUrl = (testId: number) => {
  * @summary 질문 전체 조회
  */
 export const getQuestionsDetails = async (testId: number, options?: RequestInit): Promise<getQuestionsDetailsResponse> => {
-  return kyMutator<getQuestionsDetailsResponse>(getGetQuestionsDetailsUrl(testId), {
+
+  return kyMutator<getQuestionsDetailsResponse>(getGetQuestionsDetailsUrl(testId),
+  {
     ...options,
-    method: "GET",
-  });
-};
+    method: 'GET'
 
-export const getGetQuestionsDetailsMutationOptions = <TError = ErrorType<unknown>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<Awaited<ReturnType<typeof getQuestionsDetails>>, TError, { testId: number }, TContext>;
-}): UseMutationOptions<Awaited<ReturnType<typeof getQuestionsDetails>>, TError, { testId: number }, TContext> => {
-  const mutationKey = ["getQuestionsDetails"];
-  const { mutation: mutationOptions } = options
-    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey } };
 
-  const mutationFn: MutationFunction<Awaited<ReturnType<typeof getQuestionsDetails>>, { testId: number }> = (props) => {
-    const { testId } = props ?? {};
+  }
+);}
 
-    return getQuestionsDetails(testId);
-  };
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type GetQuestionsDetailsMutationResult = NonNullable<Awaited<ReturnType<typeof getQuestionsDetails>>>;
 
-export type GetQuestionsDetailsMutationError = ErrorType<unknown>;
+export const getGetQuestionsDetailsMutationOptions = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof getQuestionsDetails>>, TError,{testId: number}, TContext>, request?: SecondParameter<typeof kyMutator>}
+): UseMutationOptions<Awaited<ReturnType<typeof getQuestionsDetails>>, TError,{testId: number}, TContext> => {
 
-/**
+const mutationKey = ['getQuestionsDetails'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof getQuestionsDetails>>, {testId: number}> = (props) => {
+          const {testId} = props ?? {};
+
+          return  getQuestionsDetails(testId,requestOptions)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type GetQuestionsDetailsMutationResult = NonNullable<Awaited<ReturnType<typeof getQuestionsDetails>>>
+
+    export type GetQuestionsDetailsMutationError = ErrorType<unknown>
+
+    /**
  * @summary 질문 전체 조회
  */
-export const useGetQuestionsDetails = <TError = ErrorType<unknown>, TContext = unknown>(
-  options?: { mutation?: UseMutationOptions<Awaited<ReturnType<typeof getQuestionsDetails>>, TError, { testId: number }, TContext> },
-  queryClient?: QueryClient,
-): UseMutationResult<Awaited<ReturnType<typeof getQuestionsDetails>>, TError, { testId: number }, TContext> => {
-  return useMutation(getGetQuestionsDetailsMutationOptions(options), queryClient);
-};
+export const useGetQuestionsDetails = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof getQuestionsDetails>>, TError,{testId: number}, TContext>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof getQuestionsDetails>>,
+        TError,
+        {testId: number},
+        TContext
+      > => {
+      return useMutation(getGetQuestionsDetailsMutationOptions(options), queryClient);
+    }
 
 export type createQuestionsResponse200 = {
-  data: ApiResponseQuestionCreateResponse;
-  status: 200;
-};
+  data: ApiResponseQuestionCreateResponse
+  status: 200
+}
 
-export type createQuestionsResponseSuccess = createQuestionsResponse200 & {
+export type createQuestionsResponseSuccess = (createQuestionsResponse200) & {
   headers: Headers;
 };
-export type createQuestionsResponse = createQuestionsResponseSuccess;
+;
 
-export const getCreateQuestionsUrl = (testId: number) => {
-  return `/api/v1/tests/${testId}/questions`;
-};
+export type createQuestionsResponse = (createQuestionsResponseSuccess)
+
+export const getCreateQuestionsUrl = (testId: number,) => {
+
+
+
+
+  return `/api/v1/tests/${testId}/questions`
+}
 
 /**
  * 여러 유형의 질문 문항을 한 번에 등록합니다. MKTT_03 (질문 목록) 화면에 해당하는 api 입니다.
@@ -403,92 +446,123 @@ export const getCreateQuestionsUrl = (testId: number) => {
 
  * @summary 질문 전체 등록
  */
-export const createQuestions = async (testId: number, questionCreateRequest: QuestionCreateRequest, options?: RequestInit): Promise<createQuestionsResponse> => {
-  return kyMutator<createQuestionsResponse>(getCreateQuestionsUrl(testId), {
+export const createQuestions = async (testId: number,
+    questionCreateRequest: QuestionCreateRequest, options?: RequestInit): Promise<createQuestionsResponse> => {
+
+  return kyMutator<createQuestionsResponse>(getCreateQuestionsUrl(testId),
+  {
     ...options,
-    method: "POST",
-    headers: { "Content-Type": "application/json", ...options?.headers },
-    body: JSON.stringify(questionCreateRequest),
-  });
-};
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(questionCreateRequest)
+  }
+);}
 
-export const getCreateQuestionsQueryKey = (testId: number, questionCreateRequest?: QuestionCreateRequest) => {
-  return ["POST", `/api/v1/tests/${testId}/questions`, questionCreateRequest] as const;
-};
 
-export const getCreateQuestionsQueryOptions = <TData = Awaited<ReturnType<typeof createQuestions>>, TError = ErrorType<unknown>>(
-  testId: number,
-  questionCreateRequest: QuestionCreateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData>> },
+
+
+
+export const getCreateQuestionsQueryKey = (testId: number,
+    questionCreateRequest?: QuestionCreateRequest,) => {
+    return [
+    'POST', `/api/v1/tests/${testId}/questions`, questionCreateRequest
+    ] as const;
+    }
+
+
+export const getCreateQuestionsQueryOptions = <TData = Awaited<ReturnType<typeof createQuestions>>, TError = ErrorType<unknown>>(testId: number,
+    questionCreateRequest: QuestionCreateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
 ) => {
-  const { query: queryOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getCreateQuestionsQueryKey(testId, questionCreateRequest);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof createQuestions>>> = ({ signal }) => createQuestions(testId, questionCreateRequest, { signal });
+  const queryKey =  queryOptions?.queryKey ?? getCreateQuestionsQueryKey(testId,questionCreateRequest);
 
-  return { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData> & {
-    queryKey: DataTag<QueryKey, TData, TError>;
-  };
-};
 
-export type CreateQuestionsQueryResult = NonNullable<Awaited<ReturnType<typeof createQuestions>>>;
-export type CreateQuestionsQueryError = ErrorType<unknown>;
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof createQuestions>>> = ({ signal }) => createQuestions(testId,questionCreateRequest, { signal, ...requestOptions });
+
+
+
+
+
+   return  { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type CreateQuestionsQueryResult = NonNullable<Awaited<ReturnType<typeof createQuestions>>>
+export type CreateQuestionsQueryError = ErrorType<unknown>
+
 
 export function useCreateQuestions<TData = Awaited<ReturnType<typeof createQuestions>>, TError = ErrorType<unknown>>(
-  testId: number,
-  questionCreateRequest: QuestionCreateRequest,
-  options: {
-    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData>> &
-      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof createQuestions>>, TError, Awaited<ReturnType<typeof createQuestions>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number,
+    questionCreateRequest: QuestionCreateRequest, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof createQuestions>>,
+          TError,
+          Awaited<ReturnType<typeof createQuestions>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useCreateQuestions<TData = Awaited<ReturnType<typeof createQuestions>>, TError = ErrorType<unknown>>(
-  testId: number,
-  questionCreateRequest: QuestionCreateRequest,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData>> &
-      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof createQuestions>>, TError, Awaited<ReturnType<typeof createQuestions>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number,
+    questionCreateRequest: QuestionCreateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof createQuestions>>,
+          TError,
+          Awaited<ReturnType<typeof createQuestions>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useCreateQuestions<TData = Awaited<ReturnType<typeof createQuestions>>, TError = ErrorType<unknown>>(
-  testId: number,
-  questionCreateRequest: QuestionCreateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number,
+    questionCreateRequest: QuestionCreateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
  * @summary 질문 전체 등록
  */
 
 export function useCreateQuestions<TData = Awaited<ReturnType<typeof createQuestions>>, TError = ErrorType<unknown>>(
-  testId: number,
-  questionCreateRequest: QuestionCreateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getCreateQuestionsQueryOptions(testId, questionCreateRequest, options);
+ testId: number,
+    questionCreateRequest: QuestionCreateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof createQuestions>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+  const queryOptions = getCreateQuestionsQueryOptions(testId,questionCreateRequest,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
+
+
+
+
+
+
 export type getQuestionDetailResponseDefault = {
-  data: unknown;
-  status: number;
-};
-export type getQuestionDetailResponseError = getQuestionDetailResponseDefault & {
+  data: unknown
+  status: number
+}
+
+;
+export type getQuestionDetailResponseError = (getQuestionDetailResponseDefault) & {
   headers: Headers;
 };
 
-export type getQuestionDetailResponse = getQuestionDetailResponseError;
+export type getQuestionDetailResponse = (getQuestionDetailResponseError)
 
-export const getGetQuestionDetailUrl = (testId: number, questionId: number) => {
-  return `/api/v1/tests/${testId}/questions/${questionId}`;
-};
+export const getGetQuestionDetailUrl = (testId: number,
+    questionId: number,) => {
+
+
+
+
+  return `/api/v1/tests/${testId}/questions/${questionId}`
+}
 
 /**
  * testId에 해당하는 테스트의 특정 질문 문항 하나를 상세조회합니다. 통계의 질문 탭 MKST_01 화면에 해당하는 api입니다.
@@ -499,59 +573,85 @@ export const getGetQuestionDetailUrl = (testId: number, questionId: number) => {
 
  * @summary 질문 상세 조회
  */
-export const getQuestionDetail = async (testId: number, questionId: number, options?: RequestInit): Promise<getQuestionDetailResponse> => {
-  return kyMutator<getQuestionDetailResponse>(getGetQuestionDetailUrl(testId, questionId), {
+export const getQuestionDetail = async (testId: number,
+    questionId: number, options?: RequestInit): Promise<getQuestionDetailResponse> => {
+
+  return kyMutator<getQuestionDetailResponse>(getGetQuestionDetailUrl(testId,questionId),
+  {
     ...options,
-    method: "GET",
-  });
-};
+    method: 'GET'
 
-export const getGetQuestionDetailMutationOptions = <TError = ErrorType<unknown>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<Awaited<ReturnType<typeof getQuestionDetail>>, TError, { testId: number; questionId: number }, TContext>;
-}): UseMutationOptions<Awaited<ReturnType<typeof getQuestionDetail>>, TError, { testId: number; questionId: number }, TContext> => {
-  const mutationKey = ["getQuestionDetail"];
-  const { mutation: mutationOptions } = options
-    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey } };
 
-  const mutationFn: MutationFunction<Awaited<ReturnType<typeof getQuestionDetail>>, { testId: number; questionId: number }> = (props) => {
-    const { testId, questionId } = props ?? {};
+  }
+);}
 
-    return getQuestionDetail(testId, questionId);
-  };
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type GetQuestionDetailMutationResult = NonNullable<Awaited<ReturnType<typeof getQuestionDetail>>>;
 
-export type GetQuestionDetailMutationError = ErrorType<unknown>;
+export const getGetQuestionDetailMutationOptions = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof getQuestionDetail>>, TError,{testId: number;questionId: number}, TContext>, request?: SecondParameter<typeof kyMutator>}
+): UseMutationOptions<Awaited<ReturnType<typeof getQuestionDetail>>, TError,{testId: number;questionId: number}, TContext> => {
 
-/**
+const mutationKey = ['getQuestionDetail'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof getQuestionDetail>>, {testId: number;questionId: number}> = (props) => {
+          const {testId,questionId} = props ?? {};
+
+          return  getQuestionDetail(testId,questionId,requestOptions)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type GetQuestionDetailMutationResult = NonNullable<Awaited<ReturnType<typeof getQuestionDetail>>>
+
+    export type GetQuestionDetailMutationError = ErrorType<unknown>
+
+    /**
  * @summary 질문 상세 조회
  */
-export const useGetQuestionDetail = <TError = ErrorType<unknown>, TContext = unknown>(
-  options?: { mutation?: UseMutationOptions<Awaited<ReturnType<typeof getQuestionDetail>>, TError, { testId: number; questionId: number }, TContext> },
-  queryClient?: QueryClient,
-): UseMutationResult<Awaited<ReturnType<typeof getQuestionDetail>>, TError, { testId: number; questionId: number }, TContext> => {
-  return useMutation(getGetQuestionDetailMutationOptions(options), queryClient);
-};
+export const useGetQuestionDetail = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof getQuestionDetail>>, TError,{testId: number;questionId: number}, TContext>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof getQuestionDetail>>,
+        TError,
+        {testId: number;questionId: number},
+        TContext
+      > => {
+      return useMutation(getGetQuestionDetailMutationOptions(options), queryClient);
+    }
 
 export type getQuestionSummaryResponse200 = {
-  data: ApiResponseQuestionSummaryResponse;
-  status: 200;
-};
+  data: ApiResponseQuestionSummaryResponse
+  status: 200
+}
 
-export type getQuestionSummaryResponseSuccess = getQuestionSummaryResponse200 & {
+export type getQuestionSummaryResponseSuccess = (getQuestionSummaryResponse200) & {
   headers: Headers;
 };
-export type getQuestionSummaryResponse = getQuestionSummaryResponseSuccess;
+;
 
-export const getGetQuestionSummaryUrl = (testId: number) => {
-  return `/api/v1/tests/${testId}/questions/summary`;
-};
+export type getQuestionSummaryResponse = (getQuestionSummaryResponseSuccess)
+
+export const getGetQuestionSummaryUrl = (testId: number,) => {
+
+
+
+
+  return `/api/v1/tests/${testId}/questions/summary`
+}
 
 /**
  * testId에 해당하는 테스트의 질문 목록 정보를 조회합니다. 통계의 질문 탭 MKST_01 화면에 해당하는 api입니다.
@@ -562,41 +662,60 @@ export const getGetQuestionSummaryUrl = (testId: number) => {
  * @summary 질문 목록 조회
  */
 export const getQuestionSummary = async (testId: number, options?: RequestInit): Promise<getQuestionSummaryResponse> => {
-  return kyMutator<getQuestionSummaryResponse>(getGetQuestionSummaryUrl(testId), {
+
+  return kyMutator<getQuestionSummaryResponse>(getGetQuestionSummaryUrl(testId),
+  {
     ...options,
-    method: "GET",
-  });
-};
+    method: 'GET'
 
-export const getGetQuestionSummaryMutationOptions = <TError = ErrorType<unknown>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<Awaited<ReturnType<typeof getQuestionSummary>>, TError, { testId: number }, TContext>;
-}): UseMutationOptions<Awaited<ReturnType<typeof getQuestionSummary>>, TError, { testId: number }, TContext> => {
-  const mutationKey = ["getQuestionSummary"];
-  const { mutation: mutationOptions } = options
-    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey } };
 
-  const mutationFn: MutationFunction<Awaited<ReturnType<typeof getQuestionSummary>>, { testId: number }> = (props) => {
-    const { testId } = props ?? {};
+  }
+);}
 
-    return getQuestionSummary(testId);
-  };
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type GetQuestionSummaryMutationResult = NonNullable<Awaited<ReturnType<typeof getQuestionSummary>>>;
 
-export type GetQuestionSummaryMutationError = ErrorType<unknown>;
+export const getGetQuestionSummaryMutationOptions = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof getQuestionSummary>>, TError,{testId: number}, TContext>, request?: SecondParameter<typeof kyMutator>}
+): UseMutationOptions<Awaited<ReturnType<typeof getQuestionSummary>>, TError,{testId: number}, TContext> => {
 
-/**
+const mutationKey = ['getQuestionSummary'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof getQuestionSummary>>, {testId: number}> = (props) => {
+          const {testId} = props ?? {};
+
+          return  getQuestionSummary(testId,requestOptions)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type GetQuestionSummaryMutationResult = NonNullable<Awaited<ReturnType<typeof getQuestionSummary>>>
+
+    export type GetQuestionSummaryMutationError = ErrorType<unknown>
+
+    /**
  * @summary 질문 목록 조회
  */
-export const useGetQuestionSummary = <TError = ErrorType<unknown>, TContext = unknown>(
-  options?: { mutation?: UseMutationOptions<Awaited<ReturnType<typeof getQuestionSummary>>, TError, { testId: number }, TContext> },
-  queryClient?: QueryClient,
-): UseMutationResult<Awaited<ReturnType<typeof getQuestionSummary>>, TError, { testId: number }, TContext> => {
-  return useMutation(getGetQuestionSummaryMutationOptions(options), queryClient);
-};
+export const useGetQuestionSummary = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof getQuestionSummary>>, TError,{testId: number}, TContext>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof getQuestionSummary>>,
+        TError,
+        {testId: number},
+        TContext
+      > => {
+      return useMutation(getGetQuestionSummaryMutationOptions(options), queryClient);
+    }

--- a/src/shared/api/generated/test.ts
+++ b/src/shared/api/generated/test.ts
@@ -5,7 +5,10 @@
  * MATE 서버 API 문서
  * OpenAPI spec version: v1.0.0
  */
-import { useMutation, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQuery
+} from '@tanstack/react-query';
 import type {
   DataTag,
   DefinedInitialDataOptions,
@@ -18,11 +21,11 @@ import type {
   UseMutationOptions,
   UseMutationResult,
   UseQueryOptions,
-  UseQueryResult,
-} from "@tanstack/react-query";
+  UseQueryResult
+} from '@tanstack/react-query';
 
-import { kyMutator } from "../mutator";
-import type { ErrorType } from "../mutator";
+import { kyMutator } from '../mutator';
+import type { ErrorType } from '../mutator';
 /**
  * 테스트 목록·카드 노출용 요약
  */
@@ -45,75 +48,78 @@ export interface ApiResponseListTestSummaryResponse {
   data?: TestSummaryResponse[];
 }
 
-export type TestCreateRequestCategoriesItem = (typeof TestCreateRequestCategoriesItem)[keyof typeof TestCreateRequestCategoriesItem];
+export type TestCreateRequestCategoriesItem = typeof TestCreateRequestCategoriesItem[keyof typeof TestCreateRequestCategoriesItem];
+
 
 export const TestCreateRequestCategoriesItem = {
-  DAILY: "DAILY",
-  FINANCE: "FINANCE",
-  HEALTH: "HEALTH",
-  SHOPPING: "SHOPPING",
-  FOOD: "FOOD",
-  GAME: "GAME",
-  CONTENT: "CONTENT",
-  COMMUNITY: "COMMUNITY",
-  AI: "AI",
-  EDUCATION: "EDUCATION",
-  TRAVEL: "TRAVEL",
-  SOCIAL: "SOCIAL",
-  CONVENIENCE: "CONVENIENCE",
-  INFORMATION: "INFORMATION",
-  BUSINESS: "BUSINESS",
-  TRANSPORT: "TRANSPORT",
-  PUBLIC_ADMIN: "PUBLIC_ADMIN",
+  DAILY: 'DAILY',
+  FINANCE: 'FINANCE',
+  HEALTH: 'HEALTH',
+  SHOPPING: 'SHOPPING',
+  FOOD: 'FOOD',
+  GAME: 'GAME',
+  CONTENT: 'CONTENT',
+  COMMUNITY: 'COMMUNITY',
+  AI: 'AI',
+  EDUCATION: 'EDUCATION',
+  TRAVEL: 'TRAVEL',
+  SOCIAL: 'SOCIAL',
+  CONVENIENCE: 'CONVENIENCE',
+  INFORMATION: 'INFORMATION',
+  BUSINESS: 'BUSINESS',
+  TRANSPORT: 'TRANSPORT',
+  PUBLIC_ADMIN: 'PUBLIC_ADMIN',
 } as const;
 
 export interface TestCreateRequest {
   /**
-   * @minLength 0
-   * @maxLength 17
-   */
+     * @minLength 0
+     * @maxLength 17
+     */
   title?: string;
   /**
-   * @minLength 0
-   * @maxLength 60
-   */
+     * @minLength 0
+     * @maxLength 60
+     */
   description?: string;
   /**
-   * @minItems 1
-   * @maxItems 3
-   */
+     * @minItems 1
+     * @maxItems 3
+     */
   categories: TestCreateRequestCategoriesItem[];
   /**
-   * @minLength 0
-   * @maxLength 17
-   */
+     * @minLength 0
+     * @maxLength 17
+     */
   serviceName?: string;
   /**
-   * @minLength 0
-   * @maxLength 70
-   */
+     * @minLength 0
+     * @maxLength 70
+     */
   serviceDescription?: string;
   /**
-   * @minItems 0
-   * @maxItems 10
-   * @items.minLength 1
-   */
+     * @minItems 0
+     * @maxItems 10
+     * @items.minLength 1
+     */
   imageKeys?: string[];
 }
 
-export type TestCreateResponseTestStatus = (typeof TestCreateResponseTestStatus)[keyof typeof TestCreateResponseTestStatus];
+export type TestCreateResponseTestStatus = typeof TestCreateResponseTestStatus[keyof typeof TestCreateResponseTestStatus];
+
 
 export const TestCreateResponseTestStatus = {
-  IN_PROGRESS: "IN_PROGRESS",
-  COMPLETED: "COMPLETED",
+  IN_PROGRESS: 'IN_PROGRESS',
+  COMPLETED: 'COMPLETED',
 } as const;
 
-export type TestCreateResponseApprovalStatus = (typeof TestCreateResponseApprovalStatus)[keyof typeof TestCreateResponseApprovalStatus];
+export type TestCreateResponseApprovalStatus = typeof TestCreateResponseApprovalStatus[keyof typeof TestCreateResponseApprovalStatus];
+
 
 export const TestCreateResponseApprovalStatus = {
-  WAITING: "WAITING",
-  ACCEPTED: "ACCEPTED",
-  REJECTED: "REJECTED",
+  WAITING: 'WAITING',
+  ACCEPTED: 'ACCEPTED',
+  REJECTED: 'REJECTED',
 } as const;
 
 export interface TestCreateResponse {
@@ -179,74 +185,77 @@ export interface ApiResponseVoid {
   data?: ApiResponseVoidData;
 }
 
-export type TestUpdateRequestCategoriesItem = (typeof TestUpdateRequestCategoriesItem)[keyof typeof TestUpdateRequestCategoriesItem];
+export type TestUpdateRequestCategoriesItem = typeof TestUpdateRequestCategoriesItem[keyof typeof TestUpdateRequestCategoriesItem];
+
 
 export const TestUpdateRequestCategoriesItem = {
-  DAILY: "DAILY",
-  FINANCE: "FINANCE",
-  HEALTH: "HEALTH",
-  SHOPPING: "SHOPPING",
-  FOOD: "FOOD",
-  GAME: "GAME",
-  CONTENT: "CONTENT",
-  COMMUNITY: "COMMUNITY",
-  AI: "AI",
-  EDUCATION: "EDUCATION",
-  TRAVEL: "TRAVEL",
-  SOCIAL: "SOCIAL",
-  CONVENIENCE: "CONVENIENCE",
-  INFORMATION: "INFORMATION",
-  BUSINESS: "BUSINESS",
-  TRANSPORT: "TRANSPORT",
-  PUBLIC_ADMIN: "PUBLIC_ADMIN",
+  DAILY: 'DAILY',
+  FINANCE: 'FINANCE',
+  HEALTH: 'HEALTH',
+  SHOPPING: 'SHOPPING',
+  FOOD: 'FOOD',
+  GAME: 'GAME',
+  CONTENT: 'CONTENT',
+  COMMUNITY: 'COMMUNITY',
+  AI: 'AI',
+  EDUCATION: 'EDUCATION',
+  TRAVEL: 'TRAVEL',
+  SOCIAL: 'SOCIAL',
+  CONVENIENCE: 'CONVENIENCE',
+  INFORMATION: 'INFORMATION',
+  BUSINESS: 'BUSINESS',
+  TRANSPORT: 'TRANSPORT',
+  PUBLIC_ADMIN: 'PUBLIC_ADMIN',
 } as const;
 
 export interface TestUpdateRequest {
   /**
-   * @minLength 0
-   * @maxLength 17
-   */
+     * @minLength 0
+     * @maxLength 17
+     */
   title?: string;
   /**
-   * @minLength 0
-   * @maxLength 60
-   */
+     * @minLength 0
+     * @maxLength 60
+     */
   description?: string;
   /**
-   * @minItems 1
-   * @maxItems 3
-   */
+     * @minItems 1
+     * @maxItems 3
+     */
   categories?: TestUpdateRequestCategoriesItem[];
   /**
-   * @minLength 0
-   * @maxLength 17
-   */
+     * @minLength 0
+     * @maxLength 17
+     */
   serviceName?: string;
   /**
-   * @minLength 0
-   * @maxLength 70
-   */
+     * @minLength 0
+     * @maxLength 70
+     */
   serviceDescription?: string;
   /**
-   * @minItems 0
-   * @maxItems 10
-   */
+     * @minItems 0
+     * @maxItems 10
+     */
   imageKeys?: string[];
 }
 
-export type TestUpdateResponseTestStatus = (typeof TestUpdateResponseTestStatus)[keyof typeof TestUpdateResponseTestStatus];
+export type TestUpdateResponseTestStatus = typeof TestUpdateResponseTestStatus[keyof typeof TestUpdateResponseTestStatus];
+
 
 export const TestUpdateResponseTestStatus = {
-  IN_PROGRESS: "IN_PROGRESS",
-  COMPLETED: "COMPLETED",
+  IN_PROGRESS: 'IN_PROGRESS',
+  COMPLETED: 'COMPLETED',
 } as const;
 
-export type TestUpdateResponseApprovalStatus = (typeof TestUpdateResponseApprovalStatus)[keyof typeof TestUpdateResponseApprovalStatus];
+export type TestUpdateResponseApprovalStatus = typeof TestUpdateResponseApprovalStatus[keyof typeof TestUpdateResponseApprovalStatus];
+
 
 export const TestUpdateResponseApprovalStatus = {
-  WAITING: "WAITING",
-  ACCEPTED: "ACCEPTED",
-  REJECTED: "REJECTED",
+  WAITING: 'WAITING',
+  ACCEPTED: 'ACCEPTED',
+  REJECTED: 'REJECTED',
 } as const;
 
 export interface TestUpdateResponse {
@@ -272,19 +281,29 @@ export interface ApiResponseTestUpdateResponse {
   data?: TestUpdateResponse;
 }
 
-export type listTestsResponse200 = {
-  data: ApiResponseListTestSummaryResponse;
-  status: 200;
-};
+type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
-export type listTestsResponseSuccess = listTestsResponse200 & {
+
+
+export type listTestsResponse200 = {
+  data: ApiResponseListTestSummaryResponse
+  status: 200
+}
+
+export type listTestsResponseSuccess = (listTestsResponse200) & {
   headers: Headers;
 };
-export type listTestsResponse = listTestsResponseSuccess;
+;
+
+export type listTestsResponse = (listTestsResponseSuccess)
 
 export const getListTestsUrl = () => {
-  return `/api/v1/tests`;
-};
+
+
+
+
+  return `/api/v1/tests`
+}
 
 /**
  * 전체 테스트 요약 목록을 최신순으로 조회합니다. 발견 탭 HM_01 57 화면에 해당하는 api 입니다.
@@ -296,57 +315,84 @@ export const getListTestsUrl = () => {
 
  * @summary 테스트 목록 조회
  */
-export const listTests = async (options?: RequestInit): Promise<listTestsResponse> => {
-  return kyMutator<listTestsResponse>(getListTestsUrl(), {
+export const listTests = async ( options?: RequestInit): Promise<listTestsResponse> => {
+
+  return kyMutator<listTestsResponse>(getListTestsUrl(),
+  {
     ...options,
-    method: "GET",
-  });
-};
+    method: 'GET'
 
-export const getListTestsMutationOptions = <TError = ErrorType<unknown>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<Awaited<ReturnType<typeof listTests>>, TError, void, TContext>;
-}): UseMutationOptions<Awaited<ReturnType<typeof listTests>>, TError, void, TContext> => {
-  const mutationKey = ["listTests"];
-  const { mutation: mutationOptions } = options
-    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey } };
 
-  const mutationFn: MutationFunction<Awaited<ReturnType<typeof listTests>>, void> = () => {
-    return listTests();
-  };
+  }
+);}
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type ListTestsMutationResult = NonNullable<Awaited<ReturnType<typeof listTests>>>;
 
-export type ListTestsMutationError = ErrorType<unknown>;
 
-/**
+export const getListTestsMutationOptions = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof listTests>>, TError,void, TContext>, request?: SecondParameter<typeof kyMutator>}
+): UseMutationOptions<Awaited<ReturnType<typeof listTests>>, TError,void, TContext> => {
+
+const mutationKey = ['listTests'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof listTests>>, void> = () => {
+
+
+          return  listTests(requestOptions)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type ListTestsMutationResult = NonNullable<Awaited<ReturnType<typeof listTests>>>
+
+    export type ListTestsMutationError = ErrorType<unknown>
+
+    /**
  * @summary 테스트 목록 조회
  */
-export const useListTests = <TError = ErrorType<unknown>, TContext = unknown>(
-  options?: { mutation?: UseMutationOptions<Awaited<ReturnType<typeof listTests>>, TError, void, TContext> },
-  queryClient?: QueryClient,
-): UseMutationResult<Awaited<ReturnType<typeof listTests>>, TError, void, TContext> => {
-  return useMutation(getListTestsMutationOptions(options), queryClient);
-};
+export const useListTests = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof listTests>>, TError,void, TContext>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof listTests>>,
+        TError,
+        void,
+        TContext
+      > => {
+      return useMutation(getListTestsMutationOptions(options), queryClient);
+    }
 
 export type createTestResponse200 = {
-  data: ApiResponseTestCreateResponse;
-  status: 200;
-};
+  data: ApiResponseTestCreateResponse
+  status: 200
+}
 
-export type createTestResponseSuccess = createTestResponse200 & {
+export type createTestResponseSuccess = (createTestResponse200) & {
   headers: Headers;
 };
-export type createTestResponse = createTestResponseSuccess;
+;
+
+export type createTestResponse = (createTestResponseSuccess)
 
 export const getCreateTestUrl = () => {
-  return `/api/v1/tests`;
-};
+
+
+
+
+  return `/api/v1/tests`
+}
 
 /**
  * 새로운 테스트를 등록합니다. MKTT_02-1 ~ MKTT_02-3 (테스트 기본 정보) 화면에 해당하는 api 입니다.
@@ -364,252 +410,342 @@ AI, EDUCATION, TRAVEL, SOCIAL, CONVENIENCE, INFORMATION, BUSINESS, TRANSPORT, PU
  * @summary 테스트 등록
  */
 export const createTest = async (testCreateRequest: TestCreateRequest, options?: RequestInit): Promise<createTestResponse> => {
-  return kyMutator<createTestResponse>(getCreateTestUrl(), {
+
+  return kyMutator<createTestResponse>(getCreateTestUrl(),
+  {
     ...options,
-    method: "POST",
-    headers: { "Content-Type": "application/json", ...options?.headers },
-    body: JSON.stringify(testCreateRequest),
-  });
-};
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(testCreateRequest)
+  }
+);}
 
-export const getCreateTestQueryKey = (testCreateRequest?: TestCreateRequest) => {
-  return ["POST", `/api/v1/tests`, testCreateRequest] as const;
-};
 
-export const getCreateTestQueryOptions = <TData = Awaited<ReturnType<typeof createTest>>, TError = ErrorType<unknown>>(
-  testCreateRequest: TestCreateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData>> },
+
+
+
+export const getCreateTestQueryKey = (testCreateRequest?: TestCreateRequest,) => {
+    return [
+    'POST', `/api/v1/tests`, testCreateRequest
+    ] as const;
+    }
+
+
+export const getCreateTestQueryOptions = <TData = Awaited<ReturnType<typeof createTest>>, TError = ErrorType<unknown>>(testCreateRequest: TestCreateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
 ) => {
-  const { query: queryOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getCreateTestQueryKey(testCreateRequest);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof createTest>>> = ({ signal }) => createTest(testCreateRequest, { signal });
+  const queryKey =  queryOptions?.queryKey ?? getCreateTestQueryKey(testCreateRequest);
 
-  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> };
-};
 
-export type CreateTestQueryResult = NonNullable<Awaited<ReturnType<typeof createTest>>>;
-export type CreateTestQueryError = ErrorType<unknown>;
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof createTest>>> = ({ signal }) => createTest(testCreateRequest, { signal, ...requestOptions });
+
+
+
+
+
+   return  { queryKey, queryFn, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type CreateTestQueryResult = NonNullable<Awaited<ReturnType<typeof createTest>>>
+export type CreateTestQueryError = ErrorType<unknown>
+
 
 export function useCreateTest<TData = Awaited<ReturnType<typeof createTest>>, TError = ErrorType<unknown>>(
-  testCreateRequest: TestCreateRequest,
-  options: {
-    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData>> &
-      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof createTest>>, TError, Awaited<ReturnType<typeof createTest>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testCreateRequest: TestCreateRequest, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof createTest>>,
+          TError,
+          Awaited<ReturnType<typeof createTest>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useCreateTest<TData = Awaited<ReturnType<typeof createTest>>, TError = ErrorType<unknown>>(
-  testCreateRequest: TestCreateRequest,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData>> &
-      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof createTest>>, TError, Awaited<ReturnType<typeof createTest>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testCreateRequest: TestCreateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof createTest>>,
+          TError,
+          Awaited<ReturnType<typeof createTest>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useCreateTest<TData = Awaited<ReturnType<typeof createTest>>, TError = ErrorType<unknown>>(
-  testCreateRequest: TestCreateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testCreateRequest: TestCreateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
  * @summary 테스트 등록
  */
 
 export function useCreateTest<TData = Awaited<ReturnType<typeof createTest>>, TError = ErrorType<unknown>>(
-  testCreateRequest: TestCreateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getCreateTestQueryOptions(testCreateRequest, options);
+ testCreateRequest: TestCreateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof createTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+  const queryOptions = getCreateTestQueryOptions(testCreateRequest,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-export type likeTestResponse200 = {
-  data: ApiResponseTestLikeResponse;
-  status: 200;
-};
 
-export type likeTestResponseSuccess = likeTestResponse200 & {
+
+
+
+
+
+export type likeTestResponse200 = {
+  data: ApiResponseTestLikeResponse
+  status: 200
+}
+
+export type likeTestResponseSuccess = (likeTestResponse200) & {
   headers: Headers;
 };
-export type likeTestResponse = likeTestResponseSuccess;
+;
 
-export const getLikeTestUrl = (testId: number) => {
-  return `/api/v1/tests/${testId}/likes`;
-};
+export type likeTestResponse = (likeTestResponseSuccess)
+
+export const getLikeTestUrl = (testId: number,) => {
+
+
+
+
+  return `/api/v1/tests/${testId}/likes`
+}
 
 /**
  * 테스트를 찜하고 해당 테스트의 찜 개수를 1 증가시킵니다. HM_01 화면에 해당하는 api 입니다. 이미 찜한 테스트면 현재 상태를 반환합니다.
  * @summary 테스트 찜하기
  */
 export const likeTest = async (testId: number, options?: RequestInit): Promise<likeTestResponse> => {
-  return kyMutator<likeTestResponse>(getLikeTestUrl(testId), {
+
+  return kyMutator<likeTestResponse>(getLikeTestUrl(testId),
+  {
     ...options,
-    method: "POST",
-  });
-};
+    method: 'POST'
 
-export const getLikeTestQueryKey = (testId: number) => {
-  return ["POST", `/api/v1/tests/${testId}/likes`] as const;
-};
 
-export const getLikeTestQueryOptions = <TData = Awaited<ReturnType<typeof likeTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData>> },
+  }
+);}
+
+
+
+
+
+export const getLikeTestQueryKey = (testId: number,) => {
+    return [
+    'POST', `/api/v1/tests/${testId}/likes`
+    ] as const;
+    }
+
+
+export const getLikeTestQueryOptions = <TData = Awaited<ReturnType<typeof likeTest>>, TError = ErrorType<unknown>>(testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
 ) => {
-  const { query: queryOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getLikeTestQueryKey(testId);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof likeTest>>> = ({ signal }) => likeTest(testId, { signal });
+  const queryKey =  queryOptions?.queryKey ?? getLikeTestQueryKey(testId);
 
-  return { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData> & {
-    queryKey: DataTag<QueryKey, TData, TError>;
-  };
-};
 
-export type LikeTestQueryResult = NonNullable<Awaited<ReturnType<typeof likeTest>>>;
-export type LikeTestQueryError = ErrorType<unknown>;
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof likeTest>>> = ({ signal }) => likeTest(testId, { signal, ...requestOptions });
+
+
+
+
+
+   return  { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type LikeTestQueryResult = NonNullable<Awaited<ReturnType<typeof likeTest>>>
+export type LikeTestQueryError = ErrorType<unknown>
+
 
 export function useLikeTest<TData = Awaited<ReturnType<typeof likeTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options: {
-    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData>> &
-      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof likeTest>>, TError, Awaited<ReturnType<typeof likeTest>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof likeTest>>,
+          TError,
+          Awaited<ReturnType<typeof likeTest>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useLikeTest<TData = Awaited<ReturnType<typeof likeTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData>> &
-      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof likeTest>>, TError, Awaited<ReturnType<typeof likeTest>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof likeTest>>,
+          TError,
+          Awaited<ReturnType<typeof likeTest>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useLikeTest<TData = Awaited<ReturnType<typeof likeTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
  * @summary 테스트 찜하기
  */
 
 export function useLikeTest<TData = Awaited<ReturnType<typeof likeTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getLikeTestQueryOptions(testId, options);
+ testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof likeTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+  const queryOptions = getLikeTestQueryOptions(testId,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-export type unlikeTestResponse200 = {
-  data: ApiResponseTestLikeResponse;
-  status: 200;
-};
 
-export type unlikeTestResponseSuccess = unlikeTestResponse200 & {
+
+
+
+
+
+export type unlikeTestResponse200 = {
+  data: ApiResponseTestLikeResponse
+  status: 200
+}
+
+export type unlikeTestResponseSuccess = (unlikeTestResponse200) & {
   headers: Headers;
 };
-export type unlikeTestResponse = unlikeTestResponseSuccess;
+;
 
-export const getUnlikeTestUrl = (testId: number) => {
-  return `/api/v1/tests/${testId}/likes`;
-};
+export type unlikeTestResponse = (unlikeTestResponseSuccess)
+
+export const getUnlikeTestUrl = (testId: number,) => {
+
+
+
+
+  return `/api/v1/tests/${testId}/likes`
+}
 
 /**
  * 테스트 찜을 취소하고 해당 테스트의 찜 개수를 1 감소시킵니다. HM_01에 해당하는 api 입니다. 찜하지 않은 테스트면 현재 상태를 반환합니다.
  * @summary 테스트 찜 취소
  */
 export const unlikeTest = async (testId: number, options?: RequestInit): Promise<unlikeTestResponse> => {
-  return kyMutator<unlikeTestResponse>(getUnlikeTestUrl(testId), {
+
+  return kyMutator<unlikeTestResponse>(getUnlikeTestUrl(testId),
+  {
     ...options,
-    method: "DELETE",
-  });
-};
+    method: 'DELETE'
 
-export const getUnlikeTestQueryKey = (testId: number) => {
-  return ["DELETE", `/api/v1/tests/${testId}/likes`] as const;
-};
 
-export const getUnlikeTestQueryOptions = <TData = Awaited<ReturnType<typeof unlikeTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData>> },
+  }
+);}
+
+
+
+
+
+export const getUnlikeTestQueryKey = (testId: number,) => {
+    return [
+    'DELETE', `/api/v1/tests/${testId}/likes`
+    ] as const;
+    }
+
+
+export const getUnlikeTestQueryOptions = <TData = Awaited<ReturnType<typeof unlikeTest>>, TError = ErrorType<unknown>>(testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
 ) => {
-  const { query: queryOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getUnlikeTestQueryKey(testId);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof unlikeTest>>> = ({ signal }) => unlikeTest(testId, { signal });
+  const queryKey =  queryOptions?.queryKey ?? getUnlikeTestQueryKey(testId);
 
-  return { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData> & {
-    queryKey: DataTag<QueryKey, TData, TError>;
-  };
-};
 
-export type UnlikeTestQueryResult = NonNullable<Awaited<ReturnType<typeof unlikeTest>>>;
-export type UnlikeTestQueryError = ErrorType<unknown>;
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof unlikeTest>>> = ({ signal }) => unlikeTest(testId, { signal, ...requestOptions });
+
+
+
+
+
+   return  { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type UnlikeTestQueryResult = NonNullable<Awaited<ReturnType<typeof unlikeTest>>>
+export type UnlikeTestQueryError = ErrorType<unknown>
+
 
 export function useUnlikeTest<TData = Awaited<ReturnType<typeof unlikeTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options: {
-    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData>> &
-      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, Awaited<ReturnType<typeof unlikeTest>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof unlikeTest>>,
+          TError,
+          Awaited<ReturnType<typeof unlikeTest>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useUnlikeTest<TData = Awaited<ReturnType<typeof unlikeTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData>> &
-      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, Awaited<ReturnType<typeof unlikeTest>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof unlikeTest>>,
+          TError,
+          Awaited<ReturnType<typeof unlikeTest>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useUnlikeTest<TData = Awaited<ReturnType<typeof unlikeTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
  * @summary 테스트 찜 취소
  */
 
 export function useUnlikeTest<TData = Awaited<ReturnType<typeof unlikeTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getUnlikeTestQueryOptions(testId, options);
+ testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof unlikeTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+  const queryOptions = getUnlikeTestQueryOptions(testId,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-export type getTestResponse200 = {
-  data: ApiResponseTestDetailResponse;
-  status: 200;
-};
 
-export type getTestResponseSuccess = getTestResponse200 & {
+
+
+
+
+
+export type getTestResponse200 = {
+  data: ApiResponseTestDetailResponse
+  status: 200
+}
+
+export type getTestResponseSuccess = (getTestResponse200) & {
   headers: Headers;
 };
-export type getTestResponse = getTestResponseSuccess;
+;
 
-export const getGetTestUrl = (testId: number) => {
-  return `/api/v1/tests/${testId}`;
-};
+export type getTestResponse = (getTestResponseSuccess)
+
+export const getGetTestUrl = (testId: number,) => {
+
+
+
+
+  return `/api/v1/tests/${testId}`
+}
 
 /**
  * 특정 테스트의 상세 정보를 조회합니다. TT_01 화면에 해당하는 api 입니다.
@@ -618,142 +754,197 @@ export const getGetTestUrl = (testId: number) => {
  * @summary 테스트 상세 조회
  */
 export const getTest = async (testId: number, options?: RequestInit): Promise<getTestResponse> => {
-  return kyMutator<getTestResponse>(getGetTestUrl(testId), {
+
+  return kyMutator<getTestResponse>(getGetTestUrl(testId),
+  {
     ...options,
-    method: "GET",
-  });
-};
+    method: 'GET'
 
-export const getGetTestMutationOptions = <TError = ErrorType<unknown>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<Awaited<ReturnType<typeof getTest>>, TError, { testId: number }, TContext>;
-}): UseMutationOptions<Awaited<ReturnType<typeof getTest>>, TError, { testId: number }, TContext> => {
-  const mutationKey = ["getTest"];
-  const { mutation: mutationOptions } = options
-    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey } };
 
-  const mutationFn: MutationFunction<Awaited<ReturnType<typeof getTest>>, { testId: number }> = (props) => {
-    const { testId } = props ?? {};
+  }
+);}
 
-    return getTest(testId);
-  };
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type GetTestMutationResult = NonNullable<Awaited<ReturnType<typeof getTest>>>;
 
-export type GetTestMutationError = ErrorType<unknown>;
+export const getGetTestMutationOptions = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof getTest>>, TError,{testId: number}, TContext>, request?: SecondParameter<typeof kyMutator>}
+): UseMutationOptions<Awaited<ReturnType<typeof getTest>>, TError,{testId: number}, TContext> => {
 
-/**
+const mutationKey = ['getTest'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof getTest>>, {testId: number}> = (props) => {
+          const {testId} = props ?? {};
+
+          return  getTest(testId,requestOptions)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type GetTestMutationResult = NonNullable<Awaited<ReturnType<typeof getTest>>>
+
+    export type GetTestMutationError = ErrorType<unknown>
+
+    /**
  * @summary 테스트 상세 조회
  */
-export const useGetTest = <TError = ErrorType<unknown>, TContext = unknown>(
-  options?: { mutation?: UseMutationOptions<Awaited<ReturnType<typeof getTest>>, TError, { testId: number }, TContext> },
-  queryClient?: QueryClient,
-): UseMutationResult<Awaited<ReturnType<typeof getTest>>, TError, { testId: number }, TContext> => {
-  return useMutation(getGetTestMutationOptions(options), queryClient);
-};
+export const useGetTest = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof getTest>>, TError,{testId: number}, TContext>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof getTest>>,
+        TError,
+        {testId: number},
+        TContext
+      > => {
+      return useMutation(getGetTestMutationOptions(options), queryClient);
+    }
 
 export type deleteTestResponse200 = {
-  data: ApiResponseVoid;
-  status: 200;
-};
+  data: ApiResponseVoid
+  status: 200
+}
 
-export type deleteTestResponseSuccess = deleteTestResponse200 & {
+export type deleteTestResponseSuccess = (deleteTestResponse200) & {
   headers: Headers;
 };
-export type deleteTestResponse = deleteTestResponseSuccess;
+;
 
-export const getDeleteTestUrl = (testId: number) => {
-  return `/api/v1/tests/${testId}`;
-};
+export type deleteTestResponse = (deleteTestResponseSuccess)
+
+export const getDeleteTestUrl = (testId: number,) => {
+
+
+
+
+  return `/api/v1/tests/${testId}`
+}
 
 /**
  * 특정 테스트를 삭제(soft delete) 합니다.
  * @summary 테스트 삭제
  */
 export const deleteTest = async (testId: number, options?: RequestInit): Promise<deleteTestResponse> => {
-  return kyMutator<deleteTestResponse>(getDeleteTestUrl(testId), {
+
+  return kyMutator<deleteTestResponse>(getDeleteTestUrl(testId),
+  {
     ...options,
-    method: "DELETE",
-  });
-};
+    method: 'DELETE'
 
-export const getDeleteTestQueryKey = (testId: number) => {
-  return ["DELETE", `/api/v1/tests/${testId}`] as const;
-};
 
-export const getDeleteTestQueryOptions = <TData = Awaited<ReturnType<typeof deleteTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData>> },
+  }
+);}
+
+
+
+
+
+export const getDeleteTestQueryKey = (testId: number,) => {
+    return [
+    'DELETE', `/api/v1/tests/${testId}`
+    ] as const;
+    }
+
+
+export const getDeleteTestQueryOptions = <TData = Awaited<ReturnType<typeof deleteTest>>, TError = ErrorType<unknown>>(testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
 ) => {
-  const { query: queryOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getDeleteTestQueryKey(testId);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof deleteTest>>> = ({ signal }) => deleteTest(testId, { signal });
+  const queryKey =  queryOptions?.queryKey ?? getDeleteTestQueryKey(testId);
 
-  return { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData> & {
-    queryKey: DataTag<QueryKey, TData, TError>;
-  };
-};
 
-export type DeleteTestQueryResult = NonNullable<Awaited<ReturnType<typeof deleteTest>>>;
-export type DeleteTestQueryError = ErrorType<unknown>;
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof deleteTest>>> = ({ signal }) => deleteTest(testId, { signal, ...requestOptions });
+
+
+
+
+
+   return  { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type DeleteTestQueryResult = NonNullable<Awaited<ReturnType<typeof deleteTest>>>
+export type DeleteTestQueryError = ErrorType<unknown>
+
 
 export function useDeleteTest<TData = Awaited<ReturnType<typeof deleteTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options: {
-    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData>> &
-      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof deleteTest>>, TError, Awaited<ReturnType<typeof deleteTest>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof deleteTest>>,
+          TError,
+          Awaited<ReturnType<typeof deleteTest>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useDeleteTest<TData = Awaited<ReturnType<typeof deleteTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData>> &
-      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof deleteTest>>, TError, Awaited<ReturnType<typeof deleteTest>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof deleteTest>>,
+          TError,
+          Awaited<ReturnType<typeof deleteTest>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useDeleteTest<TData = Awaited<ReturnType<typeof deleteTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
  * @summary 테스트 삭제
  */
 
 export function useDeleteTest<TData = Awaited<ReturnType<typeof deleteTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getDeleteTestQueryOptions(testId, options);
+ testId: number, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof deleteTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+  const queryOptions = getDeleteTestQueryOptions(testId,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
   return { ...query, queryKey: queryOptions.queryKey };
 }
 
-export type updateTestResponse200 = {
-  data: ApiResponseTestUpdateResponse;
-  status: 200;
-};
 
-export type updateTestResponseSuccess = updateTestResponse200 & {
+
+
+
+
+
+export type updateTestResponse200 = {
+  data: ApiResponseTestUpdateResponse
+  status: 200
+}
+
+export type updateTestResponseSuccess = (updateTestResponse200) & {
   headers: Headers;
 };
-export type updateTestResponse = updateTestResponseSuccess;
+;
 
-export const getUpdateTestUrl = (testId: number) => {
-  return `/api/v1/tests/${testId}`;
-};
+export type updateTestResponse = (updateTestResponseSuccess)
+
+export const getUpdateTestUrl = (testId: number,) => {
+
+
+
+
+  return `/api/v1/tests/${testId}`
+}
 
 /**
  * 테스트 기본 정보를 수정합니다. MKTT_03-02 화면에 해당하는 api 입니다.
@@ -765,75 +956,93 @@ export const getUpdateTestUrl = (testId: number) => {
 
  * @summary 테스트 수정
  */
-export const updateTest = async (testId: number, testUpdateRequest: TestUpdateRequest, options?: RequestInit): Promise<updateTestResponse> => {
-  return kyMutator<updateTestResponse>(getUpdateTestUrl(testId), {
+export const updateTest = async (testId: number,
+    testUpdateRequest: TestUpdateRequest, options?: RequestInit): Promise<updateTestResponse> => {
+
+  return kyMutator<updateTestResponse>(getUpdateTestUrl(testId),
+  {
     ...options,
-    method: "PATCH",
-    headers: { "Content-Type": "application/json", ...options?.headers },
-    body: JSON.stringify(testUpdateRequest),
-  });
-};
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json', ...options?.headers },
+    body: JSON.stringify(testUpdateRequest)
+  }
+);}
 
-export const getUpdateTestQueryKey = (testId: number, testUpdateRequest?: TestUpdateRequest) => {
-  return ["PATCH", `/api/v1/tests/${testId}`, testUpdateRequest] as const;
-};
 
-export const getUpdateTestQueryOptions = <TData = Awaited<ReturnType<typeof updateTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  testUpdateRequest: TestUpdateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData>> },
+
+
+
+export const getUpdateTestQueryKey = (testId: number,
+    testUpdateRequest?: TestUpdateRequest,) => {
+    return [
+    'PATCH', `/api/v1/tests/${testId}`, testUpdateRequest
+    ] as const;
+    }
+
+
+export const getUpdateTestQueryOptions = <TData = Awaited<ReturnType<typeof updateTest>>, TError = ErrorType<unknown>>(testId: number,
+    testUpdateRequest: TestUpdateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
 ) => {
-  const { query: queryOptions } = options ?? {};
 
-  const queryKey = queryOptions?.queryKey ?? getUpdateTestQueryKey(testId, testUpdateRequest);
+const {query: queryOptions, request: requestOptions} = options ?? {};
 
-  const queryFn: QueryFunction<Awaited<ReturnType<typeof updateTest>>> = ({ signal }) => updateTest(testId, testUpdateRequest, { signal });
+  const queryKey =  queryOptions?.queryKey ?? getUpdateTestQueryKey(testId,testUpdateRequest);
 
-  return { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions } as UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData> & {
-    queryKey: DataTag<QueryKey, TData, TError>;
-  };
-};
 
-export type UpdateTestQueryResult = NonNullable<Awaited<ReturnType<typeof updateTest>>>;
-export type UpdateTestQueryError = ErrorType<unknown>;
+
+    const queryFn: QueryFunction<Awaited<ReturnType<typeof updateTest>>> = ({ signal }) => updateTest(testId,testUpdateRequest, { signal, ...requestOptions });
+
+
+
+
+
+   return  { queryKey, queryFn, enabled: testId !== null && testId !== undefined, ...queryOptions} as UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData> & { queryKey: DataTag<QueryKey, TData, TError> }
+}
+
+export type UpdateTestQueryResult = NonNullable<Awaited<ReturnType<typeof updateTest>>>
+export type UpdateTestQueryError = ErrorType<unknown>
+
 
 export function useUpdateTest<TData = Awaited<ReturnType<typeof updateTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  testUpdateRequest: TestUpdateRequest,
-  options: {
-    query: Partial<UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData>> &
-      Pick<DefinedInitialDataOptions<Awaited<ReturnType<typeof updateTest>>, TError, Awaited<ReturnType<typeof updateTest>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number,
+    testUpdateRequest: TestUpdateRequest, options: { query:Partial<UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData>> & Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof updateTest>>,
+          TError,
+          Awaited<ReturnType<typeof updateTest>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  DefinedUseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useUpdateTest<TData = Awaited<ReturnType<typeof updateTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  testUpdateRequest: TestUpdateRequest,
-  options?: {
-    query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData>> &
-      Pick<UndefinedInitialDataOptions<Awaited<ReturnType<typeof updateTest>>, TError, Awaited<ReturnType<typeof updateTest>>>, "initialData">;
-  },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number,
+    testUpdateRequest: TestUpdateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData>> & Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof updateTest>>,
+          TError,
+          Awaited<ReturnType<typeof updateTest>>
+        > , 'initialData'
+      >, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 export function useUpdateTest<TData = Awaited<ReturnType<typeof updateTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  testUpdateRequest: TestUpdateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+ testId: number,
+    testUpdateRequest: TestUpdateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+  ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> }
 /**
  * @summary 테스트 수정
  */
 
 export function useUpdateTest<TData = Awaited<ReturnType<typeof updateTest>>, TError = ErrorType<unknown>>(
-  testId: number,
-  testUpdateRequest: TestUpdateRequest,
-  options?: { query?: Partial<UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData>> },
-  queryClient?: QueryClient,
-): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
-  const queryOptions = getUpdateTestQueryOptions(testId, testUpdateRequest, options);
+ testId: number,
+    testUpdateRequest: TestUpdateRequest, options?: { query?:Partial<UseQueryOptions<Awaited<ReturnType<typeof updateTest>>, TError, TData>>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient
+ ):  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> } {
 
-  const query = useQuery(queryOptions, queryClient) as UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
+  const queryOptions = getUpdateTestQueryOptions(testId,testUpdateRequest,options)
+
+  const query = useQuery(queryOptions, queryClient) as  UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData, TError> };
 
   return { ...query, queryKey: queryOptions.queryKey };
 }

--- a/src/shared/api/generated/users.ts
+++ b/src/shared/api/generated/users.ts
@@ -5,16 +5,24 @@
  * MATE 서버 API 문서
  * OpenAPI spec version: v1.0.0
  */
-import { useMutation } from "@tanstack/react-query";
-import type { MutationFunction, QueryClient, UseMutationOptions, UseMutationResult } from "@tanstack/react-query";
+import {
+  useMutation
+} from '@tanstack/react-query';
+import type {
+  MutationFunction,
+  QueryClient,
+  UseMutationOptions,
+  UseMutationResult
+} from '@tanstack/react-query';
 
-import { kyMutator } from "../mutator";
-import type { ErrorType } from "../mutator";
-export type MeResponseRole = (typeof MeResponseRole)[keyof typeof MeResponseRole];
+import { kyMutator } from '../mutator';
+import type { ErrorType } from '../mutator';
+export type MeResponseRole = typeof MeResponseRole[keyof typeof MeResponseRole];
+
 
 export const MeResponseRole = {
-  USER: "USER",
-  ADMIN: "ADMIN",
+  USER: 'USER',
+  ADMIN: 'ADMIN',
 } as const;
 
 export interface MeResponse {
@@ -30,58 +38,89 @@ export interface ApiResponseMeResponse {
   data?: MeResponse;
 }
 
-export type getMeResponse200 = {
-  data: ApiResponseMeResponse;
-  status: 200;
-};
+type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
-export type getMeResponseSuccess = getMeResponse200 & {
+
+
+export type getMeResponse200 = {
+  data: ApiResponseMeResponse
+  status: 200
+}
+
+export type getMeResponseSuccess = (getMeResponse200) & {
   headers: Headers;
 };
-export type getMeResponse = getMeResponseSuccess;
+;
+
+export type getMeResponse = (getMeResponseSuccess)
 
 export const getGetMeUrl = () => {
-  return `/api/v1/users/me`;
-};
+
+
+
+
+  return `/api/v1/users/me`
+}
 
 /**
  * 현재 인증된 사용자의 정보를 조회합니다.
  * @summary 내 정보 조회
  */
-export const getMe = async (options?: RequestInit): Promise<getMeResponse> => {
-  return kyMutator<getMeResponse>(getGetMeUrl(), {
+export const getMe = async ( options?: RequestInit): Promise<getMeResponse> => {
+
+  return kyMutator<getMeResponse>(getGetMeUrl(),
+  {
     ...options,
-    method: "GET",
-  });
-};
+    method: 'GET'
 
-export const getGetMeMutationOptions = <TError = ErrorType<unknown>, TContext = unknown>(options?: {
-  mutation?: UseMutationOptions<Awaited<ReturnType<typeof getMe>>, TError, void, TContext>;
-}): UseMutationOptions<Awaited<ReturnType<typeof getMe>>, TError, void, TContext> => {
-  const mutationKey = ["getMe"];
-  const { mutation: mutationOptions } = options
-    ? options.mutation && "mutationKey" in options.mutation && options.mutation.mutationKey
-      ? options
-      : { ...options, mutation: { ...options.mutation, mutationKey } }
-    : { mutation: { mutationKey } };
 
-  const mutationFn: MutationFunction<Awaited<ReturnType<typeof getMe>>, void> = () => {
-    return getMe();
-  };
+  }
+);}
 
-  return { mutationFn, ...mutationOptions };
-};
 
-export type GetMeMutationResult = NonNullable<Awaited<ReturnType<typeof getMe>>>;
 
-export type GetMeMutationError = ErrorType<unknown>;
 
-/**
+export const getGetMeMutationOptions = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof getMe>>, TError,void, TContext>, request?: SecondParameter<typeof kyMutator>}
+): UseMutationOptions<Awaited<ReturnType<typeof getMe>>, TError,void, TContext> => {
+
+const mutationKey = ['getMe'];
+const {mutation: mutationOptions, request: requestOptions} = options ?
+      options.mutation && 'mutationKey' in options.mutation && options.mutation.mutationKey ?
+      options
+      : {...options, mutation: {...options.mutation, mutationKey}}
+      : {mutation: { mutationKey, }, request: undefined};
+
+
+
+
+      const mutationFn: MutationFunction<Awaited<ReturnType<typeof getMe>>, void> = () => {
+
+
+          return  getMe(requestOptions)
+        }
+
+
+
+
+
+
+  return  { mutationFn, ...mutationOptions }}
+
+    export type GetMeMutationResult = NonNullable<Awaited<ReturnType<typeof getMe>>>
+
+    export type GetMeMutationError = ErrorType<unknown>
+
+    /**
  * @summary 내 정보 조회
  */
-export const useGetMe = <TError = ErrorType<unknown>, TContext = unknown>(
-  options?: { mutation?: UseMutationOptions<Awaited<ReturnType<typeof getMe>>, TError, void, TContext> },
-  queryClient?: QueryClient,
-): UseMutationResult<Awaited<ReturnType<typeof getMe>>, TError, void, TContext> => {
-  return useMutation(getGetMeMutationOptions(options), queryClient);
-};
+export const useGetMe = <TError = ErrorType<unknown>,
+    TContext = unknown>(options?: { mutation?:UseMutationOptions<Awaited<ReturnType<typeof getMe>>, TError,void, TContext>, request?: SecondParameter<typeof kyMutator>}
+ , queryClient?: QueryClient): UseMutationResult<
+        Awaited<ReturnType<typeof getMe>>,
+        TError,
+        void,
+        TContext
+      > => {
+      return useMutation(getGetMeMutationOptions(options), queryClient);
+    }


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #66

## 👩🏻‍💻 작업 사항

- `useSubmitTest` 훅 생성 — 퍼널 각 스텝(문제 목록)을 API 스펙에 맞게 변환 후 테스트 등록 API 호출
- `TestCreateFunnel`에 제출 로직 연동
- `pnpm orval` 재실행으로 생성 파일 최신화 (test, question, answer, auth, file, users)

## 📢 기타(공유 사항)

- orval 재생성으로 인해 `src/shared/api/generated/` 하위 파일 diff가 크게 잡히나, 직접 수정한 내용은 없습니다.