### PR TITLE
[FEAT] 결제 퍼널 구현 및 테스트 생성 화면 연결

### DIFF
--- a/src/features/test-create/ui/TestCreateFunnel.tsx
+++ b/src/features/test-create/ui/TestCreateFunnel.tsx
@@ -16,7 +16,6 @@ import { ServiceDescriptionEditPage } from "./ServiceDescriptionEditPage";
 import { TestImageEditPage } from "./TestImageEditPage";
 import { useFunnel } from "../model/useFunnel";
 import { useTestCreateForm } from "../model/useTestCreateForm";
-import { useSubmitTest } from "../model/useSubmitTest";
 import type { BasicSubStep, EditPhase, QuestionTypeId } from "../model/types";
 import { ROUTES } from "@/shared/constants/routes";
 import { MultipleCreatePage } from "@/features/question-multiple/create";
@@ -31,7 +30,7 @@ export function TestCreateFunnel() {
   const navigate = useNavigate();
   const funnel = useFunnel();
   const form = useTestCreateForm();
-  const submitTest = useSubmitTest();
+
   const [basicSubStep, setBasicSubStep] = useState<BasicSubStep>("name");
   const [registerTab, setRegisterTab] = useState<RegisterTab>("questions");
   const [isFocused, setIsFocused] = useState(false);
@@ -215,8 +214,8 @@ export function TestCreateFunnel() {
               ? "이전"
               : "취소"
         }
-        isSubmitDisabled={submitTest.isPending || !isAllComplete || !form.questions.some((q) => !!q.data)}
-        submitLabel={submitTest.isPending ? "등록 중..." : "테스트 만들기"}
+        isSubmitDisabled={!isAllComplete || !form.questions.some((q) => !!q.data)}
+        submitLabel="테스트 만들기"
       >
         {funnel.step === "register" ? (
           <TestRegisterStep

--- a/src/features/test-create/ui/TestCreateFunnel.tsx
+++ b/src/features/test-create/ui/TestCreateFunnel.tsx
@@ -197,7 +197,7 @@ export function TestCreateFunnel() {
             funnel.prev();
           }
         }}
-        onSubmit={() => submitTest.mutate()}
+        onSubmit={() => navigate({ to: ROUTES.TEST_PAYMENT })}
         currentStep={funnel.step}
         ctaMode={ctaMode}
         isConfirmDisabled={isConfirmDisabled}

--- a/src/features/test-create/ui/TestCreateFunnel.tsx
+++ b/src/features/test-create/ui/TestCreateFunnel.tsx
@@ -26,9 +26,13 @@ import { SubjectiveCreatePage } from "@/features/question-subjective/create";
 import { FivesecCreatePage } from "@/features/question-fivesec/create";
 import { CardSortCreatePage } from "@/features/question-cardsort/create";
 
-export function TestCreateFunnel() {
+interface Props {
+  fromPayment?: boolean;
+}
+
+export function TestCreateFunnel({ fromPayment = false }: Props) {
   const navigate = useNavigate();
-  const funnel = useFunnel();
+  const funnel = useFunnel(fromPayment ? "register" : "basic");
   const form = useTestCreateForm();
 
   const [basicSubStep, setBasicSubStep] = useState<BasicSubStep>("name");
@@ -71,11 +75,14 @@ export function TestCreateFunnel() {
   }, []);
 
   useEffect(() => {
-    useTestCreateForm.getState().reset();
+    if (!fromPayment) {
+      useTestCreateForm.getState().reset();
+    }
 
     return () => {
       if (blurTimerRef.current) clearTimeout(blurTimerRef.current);
     };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const handleExitConfirm = () => {

--- a/src/features/test-payment/model/calcPayment.ts
+++ b/src/features/test-payment/model/calcPayment.ts
@@ -1,0 +1,12 @@
+export function calcPayment(testerCount: number, rewardAmount: number) {
+  const testerReward = testerCount * rewardAmount;
+  const supply = Math.round(testerReward / 0.6);
+  const fee = supply - testerReward;
+  const vat = Math.round(supply * 0.1);
+  const total = supply + vat;
+  return { testerReward, fee, vat, total };
+}
+
+export function toKRW(amount: number) {
+  return `${amount.toLocaleString()}원`;
+}

--- a/src/features/test-payment/model/types.ts
+++ b/src/features/test-payment/model/types.ts
@@ -1,0 +1,7 @@
+export type PaymentStep = "main" | "tester-count" | "reward-amount";
+
+export const TESTER_COUNT_OPTIONS = [30, 50, 100, 200, 300] as const;
+export type TesterCount = (typeof TESTER_COUNT_OPTIONS)[number];
+
+export const REWARD_AMOUNT_OPTIONS = [200, 300, 500, 700, 1000] as const;
+export type RewardAmount = (typeof REWARD_AMOUNT_OPTIONS)[number];

--- a/src/features/test-payment/ui/PaymentFunnel.tsx
+++ b/src/features/test-payment/ui/PaymentFunnel.tsx
@@ -6,9 +6,15 @@ import { type PaymentStep, type TesterCount, type RewardAmount } from "../model/
 import { calcPayment, toKRW } from "../model/calcPayment";
 import { TesterCountStep } from "./TesterCountStep";
 import { RewardAmountStep } from "./RewardAmountStep";
+import { ROUTES } from "@/shared/constants/routes";
 
 export function PaymentFunnel() {
   const navigate = useNavigate();
+
+  const handleGoBack = () => {
+    navigate({ to: ROUTES.TEST_CREATE, search: { payment: true } });
+  };
+
   const [step, setStep] = useState<PaymentStep>("main");
   const [testerCount, setTesterCount] = useState<TesterCount | null>(null);
   const [draftTesterCount, setDraftTesterCount] = useState<TesterCount | null>(null);
@@ -179,18 +185,18 @@ export function PaymentFunnel() {
           />
         </>
       )}
-      {payment != null && (
+      {payment == null ? (
+        <FixedBottomCTA color="dark" variant="weak" onClick={handleGoBack}>
+          이전
+        </FixedBottomCTA>
+      ) : (
         <FixedBottomCTA.Double
           leftButton={
-            <CTAButton color="dark" variant="weak" onClick={() => navigate({ to: ".." })}>
+            <CTAButton color="dark" variant="weak" onClick={handleGoBack}>
               이전
             </CTAButton>
           }
-          rightButton={
-            <CTAButton onClick={() => {}}>
-              {toKRW(payment.total)} 결제하기
-            </CTAButton>
-          }
+          rightButton={<CTAButton onClick={() => {}}>{toKRW(payment.total)} 결제하기</CTAButton>}
         />
       )}
     </div>

--- a/src/features/test-payment/ui/PaymentFunnel.tsx
+++ b/src/features/test-payment/ui/PaymentFunnel.tsx
@@ -1,0 +1,198 @@
+import { useState } from "react";
+import { useNavigate } from "@tanstack/react-router";
+import { adaptive } from "@toss/tds-colors";
+import { Border, CTAButton, FixedBottomCTA, ListRow, Text, Top } from "@toss/tds-mobile";
+import { type PaymentStep, type TesterCount, type RewardAmount } from "../model/types";
+import { calcPayment, toKRW } from "../model/calcPayment";
+import { TesterCountStep } from "./TesterCountStep";
+import { RewardAmountStep } from "./RewardAmountStep";
+
+export function PaymentFunnel() {
+  const navigate = useNavigate();
+  const [step, setStep] = useState<PaymentStep>("main");
+  const [testerCount, setTesterCount] = useState<TesterCount | null>(null);
+  const [draftTesterCount, setDraftTesterCount] = useState<TesterCount | null>(null);
+  const [rewardAmount, setRewardAmount] = useState<RewardAmount | null>(null);
+  const [draftRewardAmount, setDraftRewardAmount] = useState<RewardAmount | null>(null);
+
+  if (step === "tester-count") {
+    return (
+      <TesterCountStep
+        draft={draftTesterCount}
+        onSelect={setDraftTesterCount}
+        onConfirm={() => {
+          setTesterCount(draftTesterCount);
+          setStep("main");
+        }}
+        onClose={() => setStep("main")}
+      />
+    );
+  }
+
+  if (step === "reward-amount") {
+    return (
+      <RewardAmountStep
+        draft={draftRewardAmount}
+        onSelect={setDraftRewardAmount}
+        onConfirm={() => {
+          setRewardAmount(draftRewardAmount);
+          setStep("main");
+        }}
+        onClose={() => setStep("main")}
+      />
+    );
+  }
+
+  const payment =
+    testerCount != null && rewardAmount != null ? calcPayment(testerCount, rewardAmount) : null;
+
+  return (
+    <div className="flex flex-col h-full bg-white">
+      <Top
+        title={
+          <Top.TitleParagraph size={22} color={adaptive.grey900}>
+            결제하기
+          </Top.TitleParagraph>
+        }
+        subtitleBottom={
+          <Top.SubtitleParagraph>테스터 수와 리워드 금액을 설정해주세요</Top.SubtitleParagraph>
+        }
+      />
+      <ListRow
+        left={
+          <ListRow.AssetIcon name="icon-rank-1-mono" color="#4365cc" backgroundColor="#eef1fb" />
+        }
+        contents={
+          <ListRow.Texts type="1RowTypeA" top="테스터 수" topProps={{ color: adaptive.grey700 }} />
+        }
+        right={
+          testerCount != null ? (
+            <ListRow.Texts
+              type="Right1RowTypeA"
+              top={`${testerCount}명`}
+              topProps={{ color: adaptive.grey700 }}
+            />
+          ) : undefined
+        }
+        verticalPadding="large"
+        arrowType="right"
+        onClick={() => {
+          setDraftTesterCount(testerCount);
+          setStep("tester-count");
+        }}
+      />
+      {testerCount != null && (
+        <ListRow
+          left={
+            <ListRow.AssetIcon name="icon-rank-2-mono" color="#4365cc" backgroundColor="#eef1fb" />
+          }
+          contents={
+            <ListRow.Texts
+              type="1RowTypeA"
+              top="리워드 금액"
+              topProps={{ color: adaptive.grey700 }}
+            />
+          }
+          right={
+            rewardAmount != null ? (
+              <ListRow.Texts
+                type="Right1RowTypeA"
+                top={toKRW(rewardAmount)}
+                topProps={{ color: adaptive.grey700 }}
+              />
+            ) : undefined
+          }
+          verticalPadding="large"
+          arrowType="right"
+          onClick={() => {
+            setDraftRewardAmount(rewardAmount);
+            setStep("reward-amount");
+          }}
+        />
+      )}
+      {payment != null && (
+        <>
+          <Border variant="height16" />
+          <div className="flex items-center justify-between px-6 py-4">
+            <Text typography="t4" fontWeight="bold" color={adaptive.grey800}>
+              결제 금액
+            </Text>
+            <Text color={adaptive.red600} typography="st8" fontWeight="bold">
+              {toKRW(payment.total)}
+            </Text>
+          </div>
+          <ListRow
+            contents={
+              <ListRow.Texts
+                type="1RowTypeA"
+                top="테스터 리워드"
+                topProps={{ color: adaptive.grey700 }}
+              />
+            }
+            right={
+              <ListRow.Texts
+                type="Right1RowTypeA"
+                top={toKRW(payment.testerReward)}
+                topProps={{ color: adaptive.grey700 }}
+              />
+            }
+          />
+          <ListRow
+            contents={
+              <ListRow.Texts type="1RowTypeA" top="수수료" topProps={{ color: adaptive.grey700 }} />
+            }
+            right={
+              <ListRow.Texts
+                type="Right1RowTypeA"
+                top={toKRW(payment.fee)}
+                topProps={{ color: adaptive.grey700 }}
+              />
+            }
+          />
+          <ListRow
+            contents={
+              <ListRow.Texts type="1RowTypeA" top="부가세" topProps={{ color: adaptive.grey700 }} />
+            }
+            right={
+              <ListRow.Texts
+                type="Right1RowTypeA"
+                top={toKRW(payment.vat)}
+                topProps={{ color: adaptive.grey700 }}
+              />
+            }
+          />
+          <ListRow
+            contents={
+              <ListRow.Texts
+                type="1RowTypeA"
+                top="결제 합계"
+                topProps={{ color: adaptive.grey700 }}
+              />
+            }
+            right={
+              <ListRow.Texts
+                type="Right1RowTypeA"
+                top={toKRW(payment.total)}
+                topProps={{ color: adaptive.grey700 }}
+              />
+            }
+          />
+        </>
+      )}
+      {payment != null && (
+        <FixedBottomCTA.Double
+          leftButton={
+            <CTAButton color="dark" variant="weak" onClick={() => navigate({ to: ".." })}>
+              이전
+            </CTAButton>
+          }
+          rightButton={
+            <CTAButton onClick={() => {}}>
+              {toKRW(payment.total)} 결제하기
+            </CTAButton>
+          }
+        />
+      )}
+    </div>
+  );
+}

--- a/src/features/test-payment/ui/RewardAmountStep.tsx
+++ b/src/features/test-payment/ui/RewardAmountStep.tsx
@@ -1,0 +1,54 @@
+import { adaptive } from "@toss/tds-colors";
+import { Checkbox, CTAButton, FixedBottomCTA, ListRow, Top } from "@toss/tds-mobile";
+import { REWARD_AMOUNT_OPTIONS, type RewardAmount } from "../model/types";
+import { toKRW } from "../model/calcPayment";
+
+interface Props {
+  draft: RewardAmount | null;
+  onSelect: (amount: RewardAmount) => void;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function RewardAmountStep({ draft, onSelect, onConfirm, onClose }: Props) {
+  return (
+    <div className="flex flex-col min-h-screen bg-white">
+      <Top
+        title={
+          <Top.TitleParagraph size={22} color={adaptive.grey900}>
+            테스터 한 명에게 얼마씩 줄까요?
+          </Top.TitleParagraph>
+        }
+      />
+      {REWARD_AMOUNT_OPTIONS.map((amount) => (
+        <ListRow
+          key={amount}
+          role="checkbox"
+          aria-checked={draft === amount}
+          contents={
+            <ListRow.Texts
+              type="1RowTypeA"
+              top={toKRW(amount)}
+              topProps={{ color: adaptive.grey700 }}
+            />
+          }
+          right={<Checkbox.Line size={24} checked={draft === amount} />}
+          verticalPadding="large"
+          onClick={() => onSelect(amount)}
+        />
+      ))}
+      <FixedBottomCTA.Double
+        leftButton={
+          <CTAButton color="dark" variant="weak" onClick={onClose}>
+            닫기
+          </CTAButton>
+        }
+        rightButton={
+          <CTAButton disabled={draft === null} onClick={onConfirm}>
+            선택하기
+          </CTAButton>
+        }
+      />
+    </div>
+  );
+}

--- a/src/features/test-payment/ui/TesterCountStep.tsx
+++ b/src/features/test-payment/ui/TesterCountStep.tsx
@@ -1,0 +1,53 @@
+import { adaptive } from "@toss/tds-colors";
+import { Checkbox, CTAButton, FixedBottomCTA, ListRow, Top } from "@toss/tds-mobile";
+import { TESTER_COUNT_OPTIONS, type TesterCount } from "../model/types";
+
+interface Props {
+  draft: TesterCount | null;
+  onSelect: (count: TesterCount) => void;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function TesterCountStep({ draft, onSelect, onConfirm, onClose }: Props) {
+  return (
+    <div className="flex flex-col min-h-screen bg-white">
+      <Top
+        title={
+          <Top.TitleParagraph size={22} color={adaptive.grey900}>
+            몇 명에게 응답받을까요?
+          </Top.TitleParagraph>
+        }
+      />
+      {TESTER_COUNT_OPTIONS.map((count) => (
+        <ListRow
+          key={count}
+          role="checkbox"
+          aria-checked={draft === count}
+          contents={
+            <ListRow.Texts
+              type="1RowTypeA"
+              top={`${count}명`}
+              topProps={{ color: adaptive.grey700 }}
+            />
+          }
+          right={<Checkbox.Line size={24} checked={draft === count} />}
+          verticalPadding="large"
+          onClick={() => onSelect(count)}
+        />
+      ))}
+      <FixedBottomCTA.Double
+        leftButton={
+          <CTAButton color="dark" variant="weak" onClick={onClose}>
+            닫기
+          </CTAButton>
+        }
+        rightButton={
+          <CTAButton disabled={draft === null} onClick={onConfirm}>
+            선택하기
+          </CTAButton>
+        }
+      />
+    </div>
+  );
+}

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as TestIndexRouteImport } from './routes/test/index'
 import { Route as MyIndexRouteImport } from './routes/my/index'
 import { Route as InterestIndexRouteImport } from './routes/interest/index'
 import { Route as DiscoveryIndexRouteImport } from './routes/discovery/index'
+import { Route as TestPaymentRouteImport } from './routes/test/payment'
 import { Route as TestCreateRouteImport } from './routes/test/create'
 import { Route as TestTestIdRouteImport } from './routes/test/$testId'
 import { Route as DiscoveryTestIdRouteImport } from './routes/discovery/$testId'
@@ -44,6 +45,11 @@ const DiscoveryIndexRoute = DiscoveryIndexRouteImport.update({
   path: '/discovery/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const TestPaymentRoute = TestPaymentRouteImport.update({
+  id: '/test/payment',
+  path: '/test/payment',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const TestCreateRoute = TestCreateRouteImport.update({
   id: '/test/create',
   path: '/test/create',
@@ -70,6 +76,7 @@ export interface FileRoutesByFullPath {
   '/discovery/$testId': typeof DiscoveryTestIdRoute
   '/test/$testId': typeof TestTestIdRoute
   '/test/create': typeof TestCreateRoute
+  '/test/payment': typeof TestPaymentRoute
   '/discovery/': typeof DiscoveryIndexRoute
   '/interest/': typeof InterestIndexRoute
   '/my/': typeof MyIndexRoute
@@ -81,6 +88,7 @@ export interface FileRoutesByTo {
   '/discovery/$testId': typeof DiscoveryTestIdRoute
   '/test/$testId': typeof TestTestIdRoute
   '/test/create': typeof TestCreateRoute
+  '/test/payment': typeof TestPaymentRoute
   '/discovery': typeof DiscoveryIndexRoute
   '/interest': typeof InterestIndexRoute
   '/my': typeof MyIndexRoute
@@ -93,6 +101,7 @@ export interface FileRoutesById {
   '/discovery/$testId': typeof DiscoveryTestIdRoute
   '/test/$testId': typeof TestTestIdRoute
   '/test/create': typeof TestCreateRoute
+  '/test/payment': typeof TestPaymentRoute
   '/discovery/': typeof DiscoveryIndexRoute
   '/interest/': typeof InterestIndexRoute
   '/my/': typeof MyIndexRoute
@@ -106,6 +115,7 @@ export interface FileRouteTypes {
     | '/discovery/$testId'
     | '/test/$testId'
     | '/test/create'
+    | '/test/payment'
     | '/discovery/'
     | '/interest/'
     | '/my/'
@@ -117,6 +127,7 @@ export interface FileRouteTypes {
     | '/discovery/$testId'
     | '/test/$testId'
     | '/test/create'
+    | '/test/payment'
     | '/discovery'
     | '/interest'
     | '/my'
@@ -128,6 +139,7 @@ export interface FileRouteTypes {
     | '/discovery/$testId'
     | '/test/$testId'
     | '/test/create'
+    | '/test/payment'
     | '/discovery/'
     | '/interest/'
     | '/my/'
@@ -140,6 +152,7 @@ export interface RootRouteChildren {
   DiscoveryTestIdRoute: typeof DiscoveryTestIdRoute
   TestTestIdRoute: typeof TestTestIdRoute
   TestCreateRoute: typeof TestCreateRoute
+  TestPaymentRoute: typeof TestPaymentRoute
   DiscoveryIndexRoute: typeof DiscoveryIndexRoute
   InterestIndexRoute: typeof InterestIndexRoute
   MyIndexRoute: typeof MyIndexRoute
@@ -184,6 +197,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DiscoveryIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/test/payment': {
+      id: '/test/payment'
+      path: '/test/payment'
+      fullPath: '/test/payment'
+      preLoaderRoute: typeof TestPaymentRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/test/create': {
       id: '/test/create'
       path: '/test/create'
@@ -220,6 +240,7 @@ const rootRouteChildren: RootRouteChildren = {
   DiscoveryTestIdRoute: DiscoveryTestIdRoute,
   TestTestIdRoute: TestTestIdRoute,
   TestCreateRoute: TestCreateRoute,
+  TestPaymentRoute: TestPaymentRoute,
   DiscoveryIndexRoute: DiscoveryIndexRoute,
   InterestIndexRoute: InterestIndexRoute,
   MyIndexRoute: MyIndexRoute,

--- a/src/routes/test/create.tsx
+++ b/src/routes/test/create.tsx
@@ -2,5 +2,11 @@ import { createFileRoute } from '@tanstack/react-router'
 import { TestCreateFunnel } from '@/features/test-create/ui/TestCreateFunnel'
 
 export const Route = createFileRoute('/test/create')({
-  component: TestCreateFunnel,
+  validateSearch: (search: Record<string, unknown>) => ({
+    payment: search.payment === true || search.payment === 'true',
+  }),
+  component: function TestCreateRoute() {
+    const { payment } = Route.useSearch()
+    return <TestCreateFunnel fromPayment={payment} />
+  },
 })

--- a/src/routes/test/create.tsx
+++ b/src/routes/test/create.tsx
@@ -1,12 +1,10 @@
-import { createFileRoute } from '@tanstack/react-router'
+import { createFileRoute, useSearch } from '@tanstack/react-router'
 import { TestCreateFunnel } from '@/features/test-create/ui/TestCreateFunnel'
 
 export const Route = createFileRoute('/test/create')({
-  validateSearch: (search: Record<string, unknown>) => ({
-    payment: search.payment === true || search.payment === 'true',
-  }),
   component: function TestCreateRoute() {
-    const { payment } = Route.useSearch()
-    return <TestCreateFunnel fromPayment={payment} />
+    const search = useSearch({ strict: false }) as { payment?: boolean | string }
+    const fromPayment = search.payment === true || search.payment === 'true'
+    return <TestCreateFunnel fromPayment={fromPayment} />
   },
 })

--- a/src/routes/test/payment.tsx
+++ b/src/routes/test/payment.tsx
@@ -1,0 +1,6 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { PaymentFunnel } from "@/features/test-payment/ui/PaymentFunnel";
+
+export const Route = createFileRoute("/test/payment")({
+  component: PaymentFunnel,
+});

--- a/src/shared/constants/routes.ts
+++ b/src/shared/constants/routes.ts
@@ -7,4 +7,5 @@ export const ROUTES = {
   TEST_CREATE: "/test/create",
   TEST_DETAIL: "/test/$testId",
   TEST_PARTICIPATE: "/test/participate/$testId",
+  TEST_PAYMENT: "/test/payment",
 } as const;


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #72 

## 👩🏻‍💻 작업 사항
<!-- 주요 작업 내용을 간단히 작성해주세요.(스크린샷도 있으면 좋아요!) -->
### 결제 퍼널 구현 (`features/test-payment`)
- 테스터 수 선택 스텝 (`TesterCountStep`) — 30/50/100/200/300명 옵션
- 리워드 금액 선택 스텝 (`RewardAmountStep`) — 200/300/500/700/1,000원 옵션
- 메인 스텝 (`PaymentFunnel`) — 선택값 확정 후 결제 금액 요약 표시
  - 테스터 리워드 / 수수료 / 부가세 / 결제 합계 자동 계산
  - 모든 값 선택 시 하단 CTA ("이전" / "{금액}원 결제하기") 표시
  
### 계산 로직 (`calcPayment.ts`)
- 공급가 = 테스터 리워드 / 0.6
- 수수료 = 공급가 - 테스터 리워드
- 부가세 = 공급가 × 10%
- 총 결제금액 = 공급가 + 부가세

### 화면 연결
- `TestCreateFunnel` 완료 시 `/test/payment` 경로로 이동
- `ROUTES.TEST_PAYMENT` 상수 추가

## 📢 기타(공유 사항) 
<!-- 공유할 내용, 추가 논의가 필요한 사항, 배포 시 유의사항 등을 작성해주세요. -->
