### PR TITLE
[FIX] 로그인 로직에 엑세스 토큰 갱신 로직 추가

### DIFF
--- a/src/features/login/ui/AuthGuard.tsx
+++ b/src/features/login/ui/AuthGuard.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import { appLogin } from '@apps-in-toss/web-framework'
 import { loginWithToss } from '@/shared/api/generated/auth'
-import { setToken } from '@/shared/api/client'
+import { setToken, setRefreshToken } from '@/shared/api/client'
 
 type AuthStatus = 'pending' | 'authenticated' | 'unauthenticated'
 
@@ -18,8 +18,10 @@ export function AuthGuard({ children }: AuthGuardProps) {
         const { authorizationCode, referrer } = await appLogin()
         const { data: body } = await loginWithToss({ authorizationCode, referrer })
         const token = body.data?.accessToken
+        const refreshToken = body.data?.refreshToken
         if (!token) throw new Error('토큰을 받지 못했습니다.')
         setToken(token)
+        if (refreshToken) setRefreshToken(refreshToken)
         setStatus('authenticated')
       } catch {
         setStatus('unauthenticated')

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -1,14 +1,38 @@
 import ky from "ky";
 
 let _accessToken: string | null = null;
+let _refreshToken: string | null = null;
+let _refreshPromise: Promise<string> | null = null;
 
-export const setToken = (token: string) => {
-  _accessToken = token;
-};
+export const setToken = (token: string) => { _accessToken = token; };
+export const clearToken = () => { _accessToken = null; };
+export const setRefreshToken = (token: string) => { _refreshToken = token; };
+export const clearRefreshToken = () => { _refreshToken = null; };
 
-export const clearToken = () => {
-  _accessToken = null;
-};
+async function refreshAccessToken(): Promise<string> {
+  if (_refreshPromise) return _refreshPromise;
+
+  _refreshPromise = (async () => {
+    const baseUrl = import.meta.env.VITE_API_BASE_URL.replace(/\/$/, "");
+    const res = await ky
+      .post(`${baseUrl}/api/v1/auth/reissue`, {
+        json: { refreshToken: _refreshToken },
+      })
+      .json<{ data?: { accessToken?: string; refreshToken?: string } }>();
+
+    const newAccessToken = res.data?.accessToken;
+    const newRefreshToken = res.data?.refreshToken;
+    if (!newAccessToken) throw new Error("토큰 재발급 실패");
+
+    setToken(newAccessToken);
+    if (newRefreshToken) setRefreshToken(newRefreshToken);
+    return newAccessToken;
+  })().finally(() => {
+    _refreshPromise = null;
+  });
+
+  return _refreshPromise;
+}
 
 export const client = ky.create({
   prefixUrl: import.meta.env.VITE_API_BASE_URL,
@@ -18,6 +42,21 @@ export const client = ky.create({
       (request) => {
         if (_accessToken) {
           request.headers.set("Authorization", `Bearer ${_accessToken}`);
+        }
+      },
+    ],
+    afterResponse: [
+      async (request, _options, response) => {
+        if (response.status !== 401 || !_refreshToken) return response;
+
+        try {
+          const newToken = await refreshAccessToken();
+          request.headers.set("Authorization", `Bearer ${newToken}`);
+          return ky(request);
+        } catch {
+          clearToken();
+          clearRefreshToken();
+          return response;
         }
       },
     ],

--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -9,13 +9,15 @@ export const clearToken = () => { _accessToken = null; };
 export const setRefreshToken = (token: string) => { _refreshToken = token; };
 export const clearRefreshToken = () => { _refreshToken = null; };
 
+const REISSUE_PATH = "api/v1/auth/reissue";
+
 async function refreshAccessToken(): Promise<string> {
   if (_refreshPromise) return _refreshPromise;
 
   _refreshPromise = (async () => {
     const baseUrl = import.meta.env.VITE_API_BASE_URL.replace(/\/$/, "");
     const res = await ky
-      .post(`${baseUrl}/api/v1/auth/reissue`, {
+      .post(`${baseUrl}/${REISSUE_PATH}`, {
         json: { refreshToken: _refreshToken },
       })
       .json<{ data?: { accessToken?: string; refreshToken?: string } }>();
@@ -47,12 +49,13 @@ export const client = ky.create({
     ],
     afterResponse: [
       async (request, _options, response) => {
-        if (response.status !== 401 || !_refreshToken) return response;
+        if (response.status !== 401 || !_refreshToken || request.headers.has("X-Retry")) return response;
 
         try {
           const newToken = await refreshAccessToken();
           request.headers.set("Authorization", `Bearer ${newToken}`);
-          return ky(request);
+          request.headers.set("X-Retry", "true");
+          return client(request);
         } catch {
           clearToken();
           clearRefreshToken();


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [x] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #79

## 👩🏻‍💻 작업 사항

- 로그인 시 `refreshToken`을 메모리에 저장하도록 `AuthGuard` 수정
- ky `afterResponse` 훅에서 401 응답 시 `/api/v1/auth/reissue`로 액세스 토큰 자동 갱신 후 원래 요청 재시도
- 동시에 여러 401이 발생해도 reissue 요청이 한 번만 실행되도록 `_refreshPromise` 중복 방지 처리
- reissue 실패 시 양쪽 토큰 모두 clear (리프레시 토큰 만료 기간 14일이므로 별도 재로그인 처리 불필요)

## 📢 기타(공유 사항)

- `client.ts`에서 `generated/auth.ts` 순환 의존을 피하기 위해 reissue 엔드포인트를 raw ky로 직접 호출