### PR TITLE
[FEAT] 테스트 결과 질문 미리보기 및 5초 테스트 오버레이 개선

### DIFF
--- a/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
@@ -27,10 +27,11 @@ export function FivesecCountdownPhase({ remaining, imageUrl, ratio, hideCountdow
         categoryLabel="5초 테스트"
         title="5초간 아래 사진에 집중해주세요"
       />
-      <div className="flex-1 px-5 pt-4">
+      <div className="flex-1 px-5 pt-4 flex justify-center">
         <div
-          className="relative w-full overflow-hidden rounded-2xl"
+          className="relative overflow-hidden rounded-2xl"
           style={{
+            width: `min(100%, calc((100dvh - 200px) * ${RATIO_TO_CSS[ratio]}))`,
             aspectRatio: RATIO_TO_CSS[ratio],
             boxShadow: "inset 0 0 0 1px rgba(2,32,71,0.05)",
           }}

--- a/src/features/question-fivesec/answer/FivesecPreviewPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecPreviewPhase.tsx
@@ -18,11 +18,8 @@ interface Props {
 export function FivesecPreviewPhase({ ratio, onStart }: Props) {
   return (
     <div className="flex flex-col flex-1 bg-white">
-      <QuestionHeader
-        categoryLabel="5초 테스트"
-        title="5초간 아래 사진에 집중해주세요"
-      />
-      <div className="flex-1 px-5 pt-4">
+      <QuestionHeader categoryLabel="5초 테스트" title={`5초간\n아래 사진에 집중해주세요`} />
+      <div className="flex-1 px-5 pt-4 flex justify-center">
         <motion.div
           role="button"
           onClick={onStart}
@@ -30,7 +27,7 @@ export function FivesecPreviewPhase({ ratio, onStart }: Props) {
           animate={{ scale: 1, opacity: 1 }}
           transition={{ duration: 0.25, ease: "easeOut" }}
           style={{
-            width: "100%",
+            width: `min(100%, calc((100dvh - 200px) * ${RATIO_TO_CSS[ratio]}))`,
             aspectRatio: RATIO_TO_CSS[ratio],
             backgroundColor: adaptive.grey100,
             borderRadius: 16,

--- a/src/features/test-result/model/mock.ts
+++ b/src/features/test-result/model/mock.ts
@@ -1,4 +1,5 @@
 import type { QuestionResult } from "./types";
+import type { ParticipateQuestion } from "@/features/test-participate/model/types";
 
 export const MOCK_RESULTS: QuestionResult[] = [
   {
@@ -84,7 +85,144 @@ export const MOCK_RESULTS: QuestionResult[] = [
   },
 ];
 
+// 질문 탭 목록 (7가지 유형 각 1개)
 export const MOCK_QUESTIONS = [
-  { id: 1, title: "입력한 제목이 이렇게 떠요", type: "객관식" },
-  { id: 2, title: "입력한 제목이 이렇게 떠요", type: "주관식" },
+  { id: 1, title: "서비스에서 불편한 점은 무엇인가요?", type: "주관식" },
+  { id: 2, title: "자주 사용하는 기능은 무엇인가요?", type: "객관식" },
+  { id: 3, title: "전반적인 만족도는 어떠신가요?", type: "척도" },
+  { id: 4, title: "어떤 디자인이 더 마음에 드시나요?", type: "A/B 테스트" },
+  { id: 5, title: "화면에서 가장 먼저 눈에 띈 것은?", type: "5초 테스트" },
+  { id: 6, title: "카드를 분류해 주세요", type: "카드 소팅" },
+  { id: 7, title: "고객센터를 찾아보세요", type: "트리 테스트" },
+];
+
+// 질문 미리보기용 ParticipateQuestion 데이터 (MOCK_QUESTIONS와 인덱스 동일)
+export const MOCK_PREVIEW_QUESTIONS: ParticipateQuestion[] = [
+  {
+    id: "q1",
+    type: "subjective",
+    data: {
+      title: "서비스에서 불편한 점은 무엇인가요?",
+      description: "자유롭게 작성해주세요",
+      imageUrl: "",
+      placeholder: "답변을 입력해주세요",
+      maxLength: 200,
+    },
+  },
+  {
+    id: "q2",
+    type: "multiple",
+    data: {
+      title: "자주 사용하는 기능은 무엇인가요?",
+      description: "해당하는 항목을 선택해주세요",
+      choices: [
+        { id: "c1", name: "홈 화면", imageUrl: "" },
+        { id: "c2", name: "검색", imageUrl: "" },
+        { id: "c3", name: "마이페이지", imageUrl: "" },
+        { id: "c4", name: "기타", imageUrl: "" },
+      ],
+      isMultiSelectEnabled: false,
+      isOtherInputEnabled: false,
+      minSelectCount: 1,
+      maxSelectCount: 1,
+    },
+  },
+  {
+    id: "q3",
+    type: "scale",
+    data: {
+      title: "전반적인 만족도는 어떠신가요?",
+      description: "",
+      scaleCount: 5,
+      minLabel: "매우 불만족",
+      maxLabel: "매우 만족",
+    },
+  },
+  {
+    id: "q4",
+    type: "ab",
+    data: {
+      title: "어떤 디자인이 더 마음에 드시나요?",
+      description: "두 디자인 중 선호하는 것을 선택해주세요",
+      imageUrlA: "",
+      imageUrlB: "",
+      ratio: "1:1",
+    },
+  },
+  {
+    id: "q5",
+    type: "fivesec",
+    data: {
+      title: "화면에서 가장 먼저 눈에 띈 것은?",
+      description: "5초 동안 화면을 보고 기억에 남는 것을 선택해주세요",
+      imageUrl: "",
+      duration: 5,
+      answerExample: "",
+      answerType: "multiple",
+      isMultipleAnswer: false,
+      isOtherInputEnabled: false,
+      isMultiSelectEnabled: false,
+      choices: [
+        { id: "c1", name: "상단 배너", imageUrl: "" },
+        { id: "c2", name: "검색창", imageUrl: "" },
+        { id: "c3", name: "네비게이션 바", imageUrl: "" },
+      ],
+      minSelectCount: 1,
+      maxSelectCount: 1,
+    },
+  },
+  {
+    id: "q6",
+    type: "cardsort",
+    data: {
+      title: "카드를 분류해 주세요",
+      description: "각 카드를 알맞은 카테고리에 배치해주세요",
+      cards: [
+        { id: "card1", label: "홈" },
+        { id: "card2", label: "검색" },
+        { id: "card3", label: "마이페이지" },
+        { id: "card4", label: "알림" },
+        { id: "card5", label: "설정" },
+        { id: "card6", label: "고객센터" },
+      ],
+      categories: [
+        { id: "cat1", label: "자주 씀" },
+        { id: "cat2", label: "가끔 씀" },
+        { id: "cat3", label: "거의 안 씀" },
+      ],
+      requireAllPlaced: true,
+    },
+  },
+  {
+    id: "q7",
+    type: "tree",
+    data: {
+      title: "고객센터를 찾아보세요",
+      description: "메뉴를 탐색해서 원하는 항목을 찾아주세요",
+      nodes: [
+        {
+          id: "n1",
+          name: "홈",
+          children: [
+            {
+              id: "n2",
+              name: "지원",
+              children: [
+                { id: "n3", name: "고객센터", children: [] },
+                { id: "n4", name: "FAQ", children: [] },
+              ],
+            },
+            {
+              id: "n5",
+              name: "설정",
+              children: [
+                { id: "n6", name: "계정 관리", children: [] },
+                { id: "n7", name: "알림 설정", children: [] },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];

--- a/src/features/test-result/ui/DownloadSheet.tsx
+++ b/src/features/test-result/ui/DownloadSheet.tsx
@@ -1,0 +1,71 @@
+import { useState } from "react";
+import { BottomSheet, Button, Checkbox, ListRow } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+}
+
+export function DownloadSheet({ open, onClose }: Props) {
+  const [selectedFormats, setSelectedFormats] = useState({ pdf: false, csv: false });
+
+  function toggleFormat(format: "pdf" | "csv") {
+    setSelectedFormats((prev) => ({ ...prev, [format]: !prev[format] }));
+  }
+
+  return (
+    <BottomSheet
+      header={<BottomSheet.Header>다운로드할 형식을 선택해주세요</BottomSheet.Header>}
+      open={open}
+      onClose={onClose}
+      cta={
+        <BottomSheet.DoubleCTA
+          leftButton={
+            <Button color="dark" variant="weak" onClick={onClose}>
+              닫기
+            </Button>
+          }
+          // TODO: 선택한 형식(selectedFormats)으로 파일 다운로드 API 연결 후 onClick 구현
+          rightButton={
+            <Button disabled={!selectedFormats.pdf && !selectedFormats.csv}>다운받기</Button>
+          }
+        />
+      }
+    >
+      <ListRow
+        role="checkbox"
+        aria-checked={selectedFormats.pdf}
+        onClick={() => toggleFormat("pdf")}
+        left={<ListRow.AssetIcon size="xsmall" shape="original" name="icon-document-pdf" />}
+        contents={
+          <ListRow.Texts
+            type="1RowTypeA"
+            top="통계 보고서"
+            topProps={{ color: adaptive.grey700 }}
+          />
+        }
+        right={<Checkbox.Line size={24} checked={selectedFormats.pdf} />}
+        verticalPadding="large"
+      />
+      <ListRow
+        role="checkbox"
+        aria-checked={selectedFormats.csv}
+        onClick={() => toggleFormat("csv")}
+        left={
+          <ListRow.AssetIcon
+            size="xsmall"
+            shape="original"
+            name="icon-googlespreadsheet-mono"
+            color={adaptive.green600}
+          />
+        }
+        contents={
+          <ListRow.Texts type="1RowTypeA" top="CSV" topProps={{ color: adaptive.grey700 }} />
+        }
+        right={<Checkbox.Line size={24} checked={selectedFormats.csv} />}
+        verticalPadding="large"
+      />
+    </BottomSheet>
+  );
+}

--- a/src/features/test-result/ui/QuestionTabContent.tsx
+++ b/src/features/test-result/ui/QuestionTabContent.tsx
@@ -1,0 +1,52 @@
+import { Asset, Text } from "@toss/tds-mobile";
+import { adaptive } from "@toss/tds-colors";
+import { MOCK_QUESTIONS } from "../model/mock";
+
+interface Props {
+  onSelectQuestion: (index: number) => void;
+}
+
+export function QuestionTabContent({ onSelectQuestion }: Props) {
+  return (
+    <div className="flex flex-col py-4">
+      {MOCK_QUESTIONS.map((question, index) => (
+        <div
+          key={question.id}
+          role="button"
+          tabIndex={0}
+          className="w-full bg-white py-3 px-5 flex flex-row gap-1 items-center active:bg-gray-50 cursor-pointer"
+          onClick={() => onSelectQuestion(index)}
+          onKeyDown={(e) => e.key === "Enter" && onSelectQuestion(index)}
+        >
+          <div className="w-full flex flex-row gap-3 items-center">
+            <Asset.Text
+              frameShape={Asset.frameShape.CircleMedium}
+              backgroundColor={adaptive.greyOpacity100}
+              style={{ color: "#4365cb", fontSize: "13px", fontWeight: "bold" }}
+              aria-label=""
+            >
+              {String(index + 1).padStart(2, "0")}
+            </Asset.Text>
+            <div className="w-full flex flex-row gap-3 justify-between items-center">
+              <div className="w-full flex flex-col">
+                <Text display="block" color={adaptive.grey800} typography="t5" fontWeight="semibold">
+                  {question.title}
+                </Text>
+                <Text display="block" color={adaptive.grey600} typography="t6" fontWeight="medium">
+                  {question.type}
+                </Text>
+              </div>
+              <Asset.Icon
+                frameShape={Asset.frameShape.CleanW24}
+                backgroundColor="transparent"
+                name="icon-system-arrow-right-outlined"
+                aria-hidden={true}
+                ratio="1/1"
+              />
+            </div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/features/test-result/ui/TestResultPage.tsx
+++ b/src/features/test-result/ui/TestResultPage.tsx
@@ -1,9 +1,11 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { Asset, BottomCTA, BottomSheet, Button, Checkbox, ListRow, Result, Tab, Text, Top } from "@toss/tds-mobile";
+import { Asset, BottomCTA, Button, Result, Tab, Text, Top } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { ResultTabContent } from "./ResultTabContent";
-import { MOCK_QUESTIONS, MOCK_PREVIEW_QUESTIONS } from "../model/mock";
+import { QuestionTabContent } from "./QuestionTabContent";
+import { DownloadSheet } from "./DownloadSheet";
+import { MOCK_PREVIEW_QUESTIONS } from "../model/mock";
 import { QuestionRenderer } from "@/features/test-participate/ui/QuestionRenderer";
 import { FivesecAnswerPage } from "@/features/question-fivesec/answer/FivesecAnswerPage";
 
@@ -14,43 +16,27 @@ interface Props {
   status: "active" | "ended";
 }
 
-const MOTION_PROPS = {
-  className: "fixed inset-0 z-60 flex flex-col bg-white",
+const OVERLAY_MOTION = {
   initial: { opacity: 0 },
   animate: { opacity: 1 },
   exit: { opacity: 0 },
   transition: { duration: 0.2 },
 } as const;
 
-function QuestionPreviewOverlay({ question, onClose }: { question: ParticipateQuestion; onClose: () => void }) {
-  const noop = () => {};
-
-  // fivesec은 FivesecAnswerPage가 CTA를 직접 관리 (FivesecCreatePage 미리보기와 동일)
-  if (question.type === "fivesec") {
-    return (
-      <motion.div {...MOTION_PROPS} className="fixed inset-0 z-60 flex flex-col overflow-y-auto bg-white pb-10">
-        <FivesecAnswerPage
-          question={question}
-          answer={{ type: "fivesec", selectedIds: [] }}
-          onChange={noop}
-          onPrev={onClose}
-          onGoNext={onClose}
-          isFirst={false}
-          isLast={true}
-          prevLabel="돌아가기"
-          isPreview={true}
-        />
-      </motion.div>
-    );
-  }
-
+function QuestionPreviewOverlay({
+  question,
+  onClose,
+}: {
+  question: ParticipateQuestion;
+  onClose: () => void;
+}) {
   return (
-    <motion.div {...MOTION_PROPS} className="fixed inset-0 z-60 flex flex-col bg-white">
+    <motion.div {...OVERLAY_MOTION} className="fixed inset-0 z-60 flex flex-col bg-white">
       <div className="flex-1 overflow-y-auto">
         <QuestionRenderer
           question={question}
           answer={undefined}
-          onChange={noop}
+          onChange={() => {}}
           onPrev={onClose}
           onGoNext={onClose}
           isFirst={true}
@@ -64,18 +50,45 @@ function QuestionPreviewOverlay({ question, onClose }: { question: ParticipateQu
   );
 }
 
-export function TestResultPage({ testId, status }: Props) {
-  console.log(testId);
+function FivesecPreviewOverlay({
+  question,
+  onClose,
+}: {
+  question: Extract<ParticipateQuestion, { type: "fivesec" }>;
+  onClose: () => void;
+}) {
+  const [answer, setAnswer] = useState<{ type: "fivesec"; selectedIds: string[] }>({
+    type: "fivesec",
+    selectedIds: [],
+  });
+
+  return (
+    <motion.div
+      {...OVERLAY_MOTION}
+      className="fixed inset-0 z-49 flex flex-col overflow-y-auto bg-white pb-10"
+    >
+      <FivesecAnswerPage
+        question={question}
+        answer={answer}
+        onChange={setAnswer}
+        onPrev={onClose}
+        onGoNext={onClose}
+        isFirst={false}
+        isLast={true}
+        prevLabel="돌아가기"
+        isPreview={true}
+      />
+    </motion.div>
+  );
+}
+
+export function TestResultPage({ status }: Props) {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [isDownloadSheetOpen, setIsDownloadSheetOpen] = useState(false);
-  const [selectedFormats, setSelectedFormats] = useState({ pdf: false, csv: false });
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
 
   const previewQuestion = previewIndex !== null ? MOCK_PREVIEW_QUESTIONS[previewIndex] : null;
-
-  function toggleFormat(format: "pdf" | "csv") {
-    setSelectedFormats((prev) => ({ ...prev, [format]: !prev[format] }));
-  }
+  const isFivesecPreview = previewQuestion?.type === "fivesec";
 
   return (
     <div>
@@ -94,6 +107,7 @@ export function TestResultPage({ testId, status }: Props) {
           </div>
         </div>
       )}
+
       <Top
         title={
           <Top.TitleParagraph size={22} color={adaptive.grey900}>
@@ -113,6 +127,7 @@ export function TestResultPage({ testId, status }: Props) {
           <Top.SubtitleParagraph size={15}>총 8개 질문 · 100명 참여</Top.SubtitleParagraph>
         }
       />
+
       <div className="w-full h-fit bg-white flex flex-col justify-start items-start px-5 pb-3">
         <Button
           size="large"
@@ -123,6 +138,7 @@ export function TestResultPage({ testId, status }: Props) {
           통계 다운받기
         </Button>
       </div>
+
       <Tab
         fluid={false}
         size="large"
@@ -136,58 +152,8 @@ export function TestResultPage({ testId, status }: Props) {
           결과
         </Tab.Item>
       </Tab>
-      {selectedTabIndex === 0 && (
-        <div className="flex flex-col py-4">
-          {MOCK_QUESTIONS.map((question, index) => (
-            <div
-              key={question.id}
-              role="button"
-              tabIndex={0}
-              className="w-full bg-white py-3 px-5 flex flex-row gap-1 items-center active:bg-gray-50 cursor-pointer"
-              onClick={() => setPreviewIndex(index)}
-              onKeyDown={(e) => e.key === "Enter" && setPreviewIndex(index)}
-            >
-              <div className="w-full flex flex-row gap-3 items-center">
-                <Asset.Text
-                  frameShape={Asset.frameShape.CircleMedium}
-                  backgroundColor={adaptive.greyOpacity100}
-                  style={{ color: `#4365cb`, fontSize: `13px`, fontWeight: `bold` }}
-                  aria-label=""
-                >
-                  {String(index + 1).padStart(2, "0")}
-                </Asset.Text>
-                <div className="w-full flex flex-row gap-3 justify-between items-center">
-                  <div className="w-full flex flex-col">
-                    <Text
-                      display="block"
-                      color={adaptive.grey800}
-                      typography="t5"
-                      fontWeight="semibold"
-                    >
-                      {question.title}
-                    </Text>
-                    <Text
-                      display="block"
-                      color={adaptive.grey600}
-                      typography="t6"
-                      fontWeight="medium"
-                    >
-                      {question.type}
-                    </Text>
-                  </div>
-                  <Asset.Icon
-                    frameShape={Asset.frameShape.CleanW24}
-                    backgroundColor="transparent"
-                    name="icon-system-arrow-right-outlined"
-                    aria-hidden={true}
-                    ratio="1/1"
-                  />
-                </div>
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
+
+      {selectedTabIndex === 0 && <QuestionTabContent onSelectQuestion={setPreviewIndex} />}
       {selectedTabIndex === 1 && status === "active" && (
         <Result
           title="아직 진행하고 있는 테스트에요"
@@ -204,77 +170,14 @@ export function TestResultPage({ testId, status }: Props) {
       )}
       {selectedTabIndex === 1 && status === "ended" && <ResultTabContent />}
 
-      {/* 질문 미리보기 전체화면 오버레이 */}
-      {previewQuestion !== null && (
-        <QuestionPreviewOverlay
-          question={previewQuestion}
-          onClose={() => setPreviewIndex(null)}
-        />
+      {previewQuestion !== null && !isFivesecPreview && (
+        <QuestionPreviewOverlay question={previewQuestion} onClose={() => setPreviewIndex(null)} />
+      )}
+      {isFivesecPreview && previewQuestion !== null && (
+        <FivesecPreviewOverlay question={previewQuestion} onClose={() => setPreviewIndex(null)} />
       )}
 
-      {/* 다운로드 BottomSheet */}
-      <BottomSheet
-        header={
-          <BottomSheet.Header>다운로드할 형식을 선택해주세요</BottomSheet.Header>
-        }
-        open={isDownloadSheetOpen}
-        onClose={() => setIsDownloadSheetOpen(false)}
-        cta={
-          <BottomSheet.DoubleCTA
-            leftButton={
-              <Button color="dark" variant="weak" onClick={() => setIsDownloadSheetOpen(false)}>
-                닫기
-              </Button>
-            }
-            // TODO: 선택한 형식(selectedFormats)으로 파일 다운로드 API 연결 후 onClick 구현
-            rightButton={<Button disabled={!selectedFormats.pdf && !selectedFormats.csv}>다운받기</Button>}
-          />
-        }
-      >
-        <ListRow
-          role="checkbox"
-          aria-checked={selectedFormats.pdf}
-          onClick={() => toggleFormat("pdf")}
-          left={
-            <ListRow.AssetIcon
-              size="xsmall"
-              shape="original"
-              name="icon-document-pdf"
-            />
-          }
-          contents={
-            <ListRow.Texts
-              type="1RowTypeA"
-              top="통계 보고서"
-              topProps={{ color: adaptive.grey700 }}
-            />
-          }
-          right={<Checkbox.Line size={24} checked={selectedFormats.pdf} />}
-          verticalPadding="large"
-        />
-        <ListRow
-          role="checkbox"
-          aria-checked={selectedFormats.csv}
-          onClick={() => toggleFormat("csv")}
-          left={
-            <ListRow.AssetIcon
-              size="xsmall"
-              shape="original"
-              name="icon-googlespreadsheet-mono"
-              color={adaptive.green600}
-            />
-          }
-          contents={
-            <ListRow.Texts
-              type="1RowTypeA"
-              top="CSV"
-              topProps={{ color: adaptive.grey700 }}
-            />
-          }
-          right={<Checkbox.Line size={24} checked={selectedFormats.csv} />}
-          verticalPadding="large"
-        />
-      </BottomSheet>
+      <DownloadSheet open={isDownloadSheetOpen} onClose={() => setIsDownloadSheetOpen(false)} />
     </div>
   );
 }

--- a/src/features/test-result/ui/TestResultPage.tsx
+++ b/src/features/test-result/ui/TestResultPage.tsx
@@ -1,12 +1,67 @@
 import { useState } from "react";
-import { Asset, BottomSheet, Button, Checkbox, ListRow, Result, Tab, Text, Top } from "@toss/tds-mobile";
-import { ResultTabContent } from "./ResultTabContent";
+import { motion } from "framer-motion";
+import { Asset, BottomCTA, BottomSheet, Button, Checkbox, ListRow, Result, Tab, Text, Top } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
-import { MOCK_QUESTIONS } from "../model/mock";
+import { ResultTabContent } from "./ResultTabContent";
+import { MOCK_QUESTIONS, MOCK_PREVIEW_QUESTIONS } from "../model/mock";
+import { QuestionRenderer } from "@/features/test-participate/ui/QuestionRenderer";
+import { FivesecAnswerPage } from "@/features/question-fivesec/answer/FivesecAnswerPage";
+
+import type { ParticipateQuestion } from "@/features/test-participate/model/types";
 
 interface Props {
   testId: string;
   status: "active" | "ended";
+}
+
+const MOTION_PROPS = {
+  className: "fixed inset-0 z-60 flex flex-col bg-white",
+  initial: { opacity: 0 },
+  animate: { opacity: 1 },
+  exit: { opacity: 0 },
+  transition: { duration: 0.2 },
+} as const;
+
+function QuestionPreviewOverlay({ question, onClose }: { question: ParticipateQuestion; onClose: () => void }) {
+  const noop = () => {};
+
+  // fivesec은 FivesecAnswerPage가 CTA를 직접 관리 (FivesecCreatePage 미리보기와 동일)
+  if (question.type === "fivesec") {
+    return (
+      <motion.div {...MOTION_PROPS} className="fixed inset-0 z-60 flex flex-col overflow-y-auto bg-white pb-10">
+        <FivesecAnswerPage
+          question={question}
+          answer={{ type: "fivesec", selectedIds: [] }}
+          onChange={noop}
+          onPrev={onClose}
+          onGoNext={onClose}
+          isFirst={false}
+          isLast={true}
+          prevLabel="돌아가기"
+          isPreview={true}
+        />
+      </motion.div>
+    );
+  }
+
+  return (
+    <motion.div {...MOTION_PROPS} className="fixed inset-0 z-60 flex flex-col bg-white">
+      <div className="flex-1 overflow-y-auto">
+        <QuestionRenderer
+          question={question}
+          answer={undefined}
+          onChange={noop}
+          onPrev={onClose}
+          onGoNext={onClose}
+          isFirst={true}
+          isLast={true}
+        />
+      </div>
+      <BottomCTA.Single color="dark" variant="weak" onClick={onClose}>
+        뒤로가기
+      </BottomCTA.Single>
+    </motion.div>
+  );
 }
 
 export function TestResultPage({ testId, status }: Props) {
@@ -14,6 +69,9 @@ export function TestResultPage({ testId, status }: Props) {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [isDownloadSheetOpen, setIsDownloadSheetOpen] = useState(false);
   const [selectedFormats, setSelectedFormats] = useState({ pdf: false, csv: false });
+  const [previewIndex, setPreviewIndex] = useState<number | null>(null);
+
+  const previewQuestion = previewIndex !== null ? MOCK_PREVIEW_QUESTIONS[previewIndex] : null;
 
   function toggleFormat(format: "pdf" | "csv") {
     setSelectedFormats((prev) => ({ ...prev, [format]: !prev[format] }));
@@ -83,7 +141,11 @@ export function TestResultPage({ testId, status }: Props) {
           {MOCK_QUESTIONS.map((question, index) => (
             <div
               key={question.id}
-              className="w-full bg-white py-3 px-5 flex flex-row gap-1 items-center"
+              role="button"
+              tabIndex={0}
+              className="w-full bg-white py-3 px-5 flex flex-row gap-1 items-center active:bg-gray-50 cursor-pointer"
+              onClick={() => setPreviewIndex(index)}
+              onKeyDown={(e) => e.key === "Enter" && setPreviewIndex(index)}
             >
               <div className="w-full flex flex-row gap-3 items-center">
                 <Asset.Text
@@ -141,6 +203,16 @@ export function TestResultPage({ testId, status }: Props) {
         />
       )}
       {selectedTabIndex === 1 && status === "ended" && <ResultTabContent />}
+
+      {/* 질문 미리보기 전체화면 오버레이 */}
+      {previewQuestion !== null && (
+        <QuestionPreviewOverlay
+          question={previewQuestion}
+          onClose={() => setPreviewIndex(null)}
+        />
+      )}
+
+      {/* 다운로드 BottomSheet */}
       <BottomSheet
         header={
           <BottomSheet.Header>다운로드할 형식을 선택해주세요</BottomSheet.Header>


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [x] 버그 수정
-   [x] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [x] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #81 

## 👩🏻‍💻 작업 사항
<!-- 주요 작업 내용을 간단히 작성해주세요.(스크린샷도 있으면 좋아요!) -->

### 질문별 결과 통계 — 질문 미리보기 오버레이
- 테스트 결과 페이지 질문 탭에서 각 질문 클릭 시 전체화면 오버레이로 질문 미리보기
- 7가지 질문 유형(주관식, 객관식, 척도, A/B, 5초 테스트, 카드 소팅, 트리 테스트) 모두 지원
- 일반 질문: `QuestionPreviewOverlay` — `QuestionRenderer` + 인라인 `BottomCTA.Single` (뒤로가기)
- 5초 테스트: `FivesecPreviewOverlay` — `FivesecAnswerPage` 그대로 활용 (`isPreview=true`)
  - `FixedBottomCTA` portal이 z-50으로 렌더되어 오버레이를 `z-49`로 설정해 버튼 정상 노출

### 5초 테스트 이미지 비율 개선
- 기존 `width: 100%` + `aspect-ratio: 9/16` → 작은 기기에서 이미지가 화면을 벗어나는 문제
- `width: min(100%, calc((100dvh - 200px) * 비율))` 적용
  - 큰 기기: 컨테이너 너비(100%)가 binding → 기존처럼 꽉 차게 표시
  - 작은 기기: height 기반 계산값이 binding → 스크롤 없이 화면 안에 맞게 자동 축소
- `FivesecPreviewPhase`, `FivesecCountdownPhase` 동일하게 적용

### TestResultPage 컴포넌트 분리 (리팩토링)
- `QuestionTabContent.tsx` 분리 — 질문 탭 목록 (`ResultTabContent`와 대칭 구조)
- `DownloadSheet.tsx` 분리 — 다운로드 BottomSheet + `selectedFormats` state 캡슐화
- `FivesecPreviewOverlay` 함수 컴포넌트 추출 — `QuestionPreviewOverlay`와 패턴 통일

## 📢 기타(공유 사항) 
<!-- 공유할 내용, 추가 논의가 필요한 사항, 배포 시 유의사항 등을 작성해주세요. -->
