### PR TITLE
[REFACTOR] API 스펙에 맞춰 상수명 리팩토링

### DIFF
--- a/src/features/discovery-detail/ui/TestDetailHeader.tsx
+++ b/src/features/discovery-detail/ui/TestDetailHeader.tsx
@@ -1,5 +1,6 @@
 import { Top } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
+import { CATEGORY_LABEL } from "@/shared/constants/categories";
 
 interface Props {
   title: string;
@@ -17,7 +18,7 @@ export function TestDetailHeader({ title, tags }: Props) {
       subtitleBottom={
         <Top.SubtitleBadges
           badges={tags.map((tag) => ({
-            text: tag,
+            text: CATEGORY_LABEL[tag] ?? tag,
             color: "elephant" as const,
             variant: "weak" as const,
           }))}

--- a/src/features/question-ab/answer/AbAnswerPage.tsx
+++ b/src/features/question-ab/answer/AbAnswerPage.tsx
@@ -8,7 +8,7 @@ import { QUESTION_TYPE_LABEL } from "@/features/test-participate/model/constants
 export function AbAnswerPage({
   question,
   answer,
-}: QuestionAnswerProps<"ab">) {
+}: QuestionAnswerProps<"AB_TEST">) {
   const { data } = question;
   const selected = answer?.selected ?? null;
   const aspectRatio = (data.ratio ?? "9:16").replace(":", "/");
@@ -17,7 +17,7 @@ export function AbAnswerPage({
   return (
     <div className="flex flex-col">
       <QuestionHeader
-        categoryLabel={QUESTION_TYPE_LABEL.ab}
+        categoryLabel={QUESTION_TYPE_LABEL.AB_TEST}
         title={data.title}
         description={data.description}
         lower={

--- a/src/features/question-ab/create/AbCreateOptionSection.tsx
+++ b/src/features/question-ab/create/AbCreateOptionSection.tsx
@@ -1,16 +1,10 @@
 import { Asset, Button, ListRow, Text } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
-import type { AbRatio } from "@/features/question-ab/model/types";
+import { RATIO_TO_CSS, type AbRatio } from "@/features/question-ab/model/types";
 
 const IMAGE_SLOT_HORIZONTAL_PADDING = 22;
 const IMAGE_SLOT_LABEL_WIDTH = `calc(50vw - ${IMAGE_SLOT_HORIZONTAL_PADDING}px)`;
 const AB_IMAGE_WIDTH = `calc(50vw - ${IMAGE_SLOT_HORIZONTAL_PADDING}px)`;
-
-const RATIO_TO_CSS: Record<AbRatio, string> = {
-  "9:16": "9/16",
-  "1:1": "1/1",
-  "4:3": "4/3",
-};
 
 interface AbCreateOptionSectionProps {
   imageUrlA: string;

--- a/src/features/question-ab/create/AbCreatePage.tsx
+++ b/src/features/question-ab/create/AbCreatePage.tsx
@@ -32,7 +32,7 @@ export function AbCreatePage({ questionId, onClose }: AbCreatePageProps) {
   const [imageUrlB, setImageUrlB] = useState(existingAb?.imageUrlB ?? "");
   const [activeSlot, setActiveSlot] = useState<"a" | "b" | null>(null);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "ab"; selected: "A" | "B" | null }>({ type: "ab", selected: null });
+  const [previewAnswer, setPreviewAnswer] = useState<{ type: "AB_TEST"; selected: "A" | "B" | null }>({ type: "AB_TEST", selected: null });
   const [ratio, setRatio] = useState<AbRatio>(existingAb?.ratio ?? "9:16");
   const [isRatioSheetOpen, setIsRatioSheetOpen] = useState(false);
 
@@ -173,7 +173,7 @@ export function AbCreatePage({ questionId, onClose }: AbCreatePageProps) {
           <AbAnswerPage
             question={{
               id: "preview",
-              type: "ab",
+              type: "AB_TEST",
               data: {
                 title: questionTitle,
                 description: questionDescription,

--- a/src/features/question-ab/create/AbCreatePage.tsx
+++ b/src/features/question-ab/create/AbCreatePage.tsx
@@ -21,7 +21,7 @@ interface AbCreatePageProps {
 export function AbCreatePage({ questionId, onClose }: AbCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
-  const existingAb = existing?.typeId === "ab" ? existing : null;
+  const existingAb = existing?.typeId === "AB_TEST" ? existing : null;
 
   const [questionTitle, setQuestionTitle] = useState(existingAb?.title ?? "");
   const [questionDescription, setQuestionDescription] = useState(existingAb?.description ?? "");
@@ -136,7 +136,7 @@ export function AbCreatePage({ questionId, onClose }: AbCreatePageProps) {
             onCancel={onClose}
             onComplete={() => {
               updateQuestion(questionId, {
-                typeId: "ab",
+                typeId: "AB_TEST",
                 title: questionTitle,
                 description: questionDescription,
                 imageUrlA,

--- a/src/features/question-ab/model/types.ts
+++ b/src/features/question-ab/model/types.ts
@@ -1,10 +1,7 @@
-export type AbRatio = "9:16" | "1:1" | "4:3";
+import type { AbRatio } from "@/shared/constants/imageRatio";
 
-export const RATIO_TO_CSS: Record<AbRatio, string> = {
-  "9:16": "9/16",
-  "1:1": "1/1",
-  "4:3": "4/3",
-};
+export type { AbRatio };
+export { RATIO_TO_CSS } from "@/shared/constants/imageRatio";
 
 export interface AbQuestionData {
   title: string;

--- a/src/features/question-ab/model/types.ts
+++ b/src/features/question-ab/model/types.ts
@@ -1,5 +1,11 @@
 export type AbRatio = "9:16" | "1:1" | "4:3";
 
+export const RATIO_TO_CSS: Record<AbRatio, string> = {
+  "9:16": "9/16",
+  "1:1": "1/1",
+  "4:3": "4/3",
+};
+
 export interface AbQuestionData {
   title: string;
   description: string;

--- a/src/features/question-cardsort/answer/CardSortAnswerPage.tsx
+++ b/src/features/question-cardsort/answer/CardSortAnswerPage.tsx
@@ -15,7 +15,7 @@ function getCategoryColor(index: number): string {
   return adaptive.blue500;
 }
 
-export function CardSortAnswerPage({ question, answer, onChange }: QuestionAnswerProps<"cardsort">) {
+export function CardSortAnswerPage({ question, answer, onChange }: QuestionAnswerProps<"CARD_SORTING">) {
   const { data } = question;
   const placements = answer?.placements ?? {};
   const [selectedCardId, setSelectedCardId] = useState<string | null>(null);
@@ -37,7 +37,7 @@ export function CardSortAnswerPage({ question, answer, onChange }: QuestionAnswe
     if (placements[cardId]) {
       const next = { ...placements };
       delete next[cardId];
-      onChange({ type: "cardsort", placements: next });
+      onChange({ type: "CARD_SORTING", placements: next });
       return;
     }
     if (selectedCardId === cardId && !pickTooltipDone) setPickTooltipDone(true);
@@ -47,14 +47,14 @@ export function CardSortAnswerPage({ question, answer, onChange }: QuestionAnswe
   const handleCategoryTap = (categoryId: string) => {
     if (!selectedCardId) return;
     if (!pickTooltipDone) setPickTooltipDone(true);
-    onChange({ type: "cardsort", placements: { ...placements, [selectedCardId]: categoryId } });
+    onChange({ type: "CARD_SORTING", placements: { ...placements, [selectedCardId]: categoryId } });
     setSelectedCardId(null);
   };
 
   return (
     <div className="flex flex-col">
       <QuestionHeader
-        categoryLabel={QUESTION_TYPE_LABEL.cardsort}
+        categoryLabel={QUESTION_TYPE_LABEL.CARD_SORTING}
         title={data.title}
         description={data.description}
       />

--- a/src/features/question-cardsort/create/CardSortCreatePage.tsx
+++ b/src/features/question-cardsort/create/CardSortCreatePage.tsx
@@ -22,7 +22,7 @@ function generateId() {
 export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
-  const existingCardSort = existing?.typeId === "card" ? existing : null;
+  const existingCardSort = existing?.typeId === "CARD_SORTING" ? existing : null;
 
   const [questionTitle, setQuestionTitle] = useState(existingCardSort?.title ?? "");
   const [questionDescription, setQuestionDescription] = useState(existingCardSort?.description ?? "");
@@ -126,7 +126,7 @@ export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePagePr
             onCancel={onClose}
             onComplete={() => {
               updateQuestion(questionId, {
-                typeId: "card",
+                typeId: "CARD_SORTING",
                 title: questionTitle,
                 description: questionDescription,
                 categories,

--- a/src/features/question-cardsort/create/CardSortCreatePage.tsx
+++ b/src/features/question-cardsort/create/CardSortCreatePage.tsx
@@ -33,7 +33,7 @@ export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePagePr
   const [cards, setCards] = useState<CardSortCard[]>(existingCardSort?.cards ?? []);
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "cardsort"; placements: Record<string, string> }>({ type: "cardsort", placements: {} });
+  const [previewAnswer, setPreviewAnswer] = useState<{ type: "CARD_SORTING"; placements: Record<string, string> }>({ type: "CARD_SORTING", placements: {} });
 
   const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
   const [isCategorySheetOpen, setIsCategorySheetOpen] = useState(false);
@@ -174,7 +174,7 @@ export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePagePr
           <CardSortAnswerPage
             question={{
               id: "preview",
-              type: "cardsort",
+              type: "CARD_SORTING",
               data: {
                 title: questionTitle,
                 description: questionDescription,

--- a/src/features/question-fivesec/answer/FivesecAnswerPage.tsx
+++ b/src/features/question-fivesec/answer/FivesecAnswerPage.tsx
@@ -8,7 +8,7 @@ import { FivesecMultipleAnswerPhase } from "./FivesecMultipleAnswerPhase";
 
 type Phase = "ready" | "preview" | "countdown" | "answer";
 
-interface Props extends QuestionAnswerProps<"fivesec"> {
+interface Props extends QuestionAnswerProps<"FIVE_SECOND"> {
   onPrev: () => void;
   onGoNext: () => void;
   isFirst: boolean;
@@ -59,10 +59,10 @@ export function FivesecAnswerPage({ question, answer, onChange, onPrev, onGoNext
         : selectedIds.length < maxSelectCount
           ? [...selectedIds, id]
           : selectedIds;
-      onChange({ type: "fivesec", selectedIds: next });
+      onChange({ type: "FIVE_SECOND", selectedIds: next });
     } else {
       const next = selectedIds.includes(id) ? [] : [id];
-      onChange({ type: "fivesec", selectedIds: next });
+      onChange({ type: "FIVE_SECOND", selectedIds: next });
     }
   }
 
@@ -97,7 +97,7 @@ export function FivesecAnswerPage({ question, answer, onChange, onPrev, onGoNext
         isLast={isLast}
         prevLabel={prevLabel}
         onlyPrev={isPreview}
-        onChange={(text) => onChange({ type: "fivesec", selectedIds: [], text })}
+        onChange={(text) => onChange({ type: "FIVE_SECOND", selectedIds: [], text })}
         onPrev={onPrev}
         onGoNext={onGoNext}
       />

--- a/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
@@ -1,12 +1,6 @@
 import { motion } from "framer-motion";
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
-import type { AbRatio } from "@/features/question-ab/model/types";
-
-const RATIO_TO_CSS: Record<AbRatio, string> = {
-  "9:16": "9/16",
-  "1:1": "1/1",
-  "4:3": "4/3",
-};
+import { RATIO_TO_CSS } from "@/features/question-ab/model/types";
 
 interface Props {
   remaining: number;

--- a/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
-import { RATIO_TO_CSS } from "@/features/question-ab/model/types";
+import { RATIO_TO_CSS } from "@/shared/constants/imageRatio";
 
 interface Props {
   remaining: number;

--- a/src/features/question-fivesec/answer/FivesecPreviewPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecPreviewPhase.tsx
@@ -2,7 +2,7 @@ import { motion } from "framer-motion";
 import { adaptive } from "@toss/tds-colors";
 import { Text } from "@toss/tds-mobile";
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
-import { RATIO_TO_CSS } from "@/features/question-ab/model/types";
+import { RATIO_TO_CSS } from "@/shared/constants/imageRatio";
 
 interface Props {
   ratio: AbRatio;

--- a/src/features/question-fivesec/answer/FivesecPreviewPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecPreviewPhase.tsx
@@ -2,13 +2,7 @@ import { motion } from "framer-motion";
 import { adaptive } from "@toss/tds-colors";
 import { Text } from "@toss/tds-mobile";
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
-import type { AbRatio } from "@/features/question-ab/model/types";
-
-const RATIO_TO_CSS: Record<AbRatio, string> = {
-  "9:16": "9/16",
-  "1:1": "1/1",
-  "4:3": "4/3",
-};
+import { RATIO_TO_CSS } from "@/features/question-ab/model/types";
 
 interface Props {
   ratio: AbRatio;

--- a/src/features/question-fivesec/create/FivesecCreatePage.tsx
+++ b/src/features/question-fivesec/create/FivesecCreatePage.tsx
@@ -80,7 +80,7 @@ export function FivesecCreatePage({
   const [ratio, setRatio] = useState<AbRatio>(existingFivesec?.ratio ?? "9:16");
   const [isRatioSheetOpen, setIsRatioSheetOpen] = useState(false);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "fivesec"; selectedIds: string[]; text?: string }>({ type: "fivesec", selectedIds: [] });
+  const [previewAnswer, setPreviewAnswer] = useState<{ type: "FIVE_SECOND"; selectedIds: string[]; text?: string }>({ type: "FIVE_SECOND", selectedIds: [] });
 
   const hasTitle = title.trim().length > 0;
   const editingChoice =
@@ -390,7 +390,7 @@ export function FivesecCreatePage({
           <FivesecAnswerPage
             question={{
               id: "preview",
-              type: "fivesec",
+              type: "FIVE_SECOND",
               data: {
                 title,
                 description,

--- a/src/features/question-fivesec/create/FivesecCreatePage.tsx
+++ b/src/features/question-fivesec/create/FivesecCreatePage.tsx
@@ -40,7 +40,7 @@ export function FivesecCreatePage({
 }: FivesecCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
-  const existingFivesec = existing?.typeId === "fivesec" ? existing : null;
+  const existingFivesec = existing?.typeId === "FIVE_SECOND" ? existing : null;
 
   const [title, setTitle] = useState(existingFivesec?.title ?? "");
   const [description, setDescription] = useState(existingFivesec?.description ?? "");
@@ -354,7 +354,7 @@ export function FivesecCreatePage({
                 disabled={isCompleteDisabled}
                 onClick={() => {
                   updateQuestion(questionId, {
-                    typeId: "fivesec",
+                    typeId: "FIVE_SECOND",
                     title,
                     description,
                     imageUrl,

--- a/src/features/question-fivesec/create/FivesecCreatePage.tsx
+++ b/src/features/question-fivesec/create/FivesecCreatePage.tsx
@@ -27,7 +27,7 @@ import { useTestCreateForm } from "@/features/test-create/model/useTestCreateFor
 import { FivesecMultipleChoiceSection } from "./FivesecMultipleChoiceSection";
 import { AbRatioSelectSheet } from "@/features/question-ab/create/AbRatioSelectSheet";
 import { FivesecAnswerTypeSheet } from "./FivesecAnswerTypeSheet";
-import { RATIO_TO_CSS, type AbRatio } from "@/features/question-ab/model/types";
+import { RATIO_TO_CSS, type AbRatio } from "@/shared/constants/imageRatio";
 
 interface FivesecCreatePageProps {
   questionId: string;

--- a/src/features/question-fivesec/create/FivesecCreatePage.tsx
+++ b/src/features/question-fivesec/create/FivesecCreatePage.tsx
@@ -27,13 +27,7 @@ import { useTestCreateForm } from "@/features/test-create/model/useTestCreateFor
 import { FivesecMultipleChoiceSection } from "./FivesecMultipleChoiceSection";
 import { AbRatioSelectSheet } from "@/features/question-ab/create/AbRatioSelectSheet";
 import { FivesecAnswerTypeSheet } from "./FivesecAnswerTypeSheet";
-import type { AbRatio } from "@/features/question-ab/model/types";
-
-const RATIO_TO_CSS: Record<AbRatio, string> = {
-  "9:16": "9/16",
-  "1:1": "1/1",
-  "4:3": "4/3",
-};
+import { RATIO_TO_CSS, type AbRatio } from "@/features/question-ab/model/types";
 
 interface FivesecCreatePageProps {
   questionId: string;

--- a/src/features/question-fivesec/model/types.ts
+++ b/src/features/question-fivesec/model/types.ts
@@ -1,5 +1,5 @@
 import type { MultipleChoiceItem } from "@/features/question-multiple/model/types";
-import type { AbRatio } from "@/features/question-ab/model/types";
+import type { AbRatio } from "@/shared/constants/imageRatio";
 
 export type { AbRatio };
 

--- a/src/features/question-multiple/answer/MultipleAnswerPage.tsx
+++ b/src/features/question-multiple/answer/MultipleAnswerPage.tsx
@@ -2,7 +2,7 @@ import { Checkbox, List, ListRow } from "@toss/tds-mobile";
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
 import type { QuestionAnswerProps } from "@/features/test-participate/model/types";
 
-type Props = QuestionAnswerProps<"multiple">;
+type Props = QuestionAnswerProps<"OBJECTIVE">;
 
 export function MultipleAnswerPage({ question, answer, onChange }: Props) {
   const { title, description, choices, isMultiSelectEnabled, maxSelectCount } =
@@ -18,10 +18,10 @@ export function MultipleAnswerPage({ question, answer, onChange }: Props) {
         : selectedIds.length < maxSelectCount
           ? [...selectedIds, id]
           : selectedIds;
-      onChange({ type: "multiple", selectedIds: next });
+      onChange({ type: "OBJECTIVE", selectedIds: next });
     } else {
       const next = selectedIds.includes(id) ? [] : [id];
-      onChange({ type: "multiple", selectedIds: next });
+      onChange({ type: "OBJECTIVE", selectedIds: next });
     }
   }
 

--- a/src/features/question-multiple/create/MultipleCreatePage.tsx
+++ b/src/features/question-multiple/create/MultipleCreatePage.tsx
@@ -21,7 +21,7 @@ export function MultipleCreatePage({
 }: MultipleCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
-  const existingMultiple = existing?.typeId === "multiple" ? existing : null;
+  const existingMultiple = existing?.typeId === "OBJECTIVE" ? existing : null;
 
   const [isOtherInputEnabled, setIsOtherInputEnabled] = useState(
     existingMultiple?.isOtherInputEnabled ?? false,
@@ -127,7 +127,7 @@ export function MultipleCreatePage({
             onCancel={onClose}
             onComplete={() => {
               updateQuestion(questionId, {
-                typeId: "multiple",
+                typeId: "OBJECTIVE",
                 title: questionTitle,
                 description: questionDescription,
                 choices,

--- a/src/features/question-multiple/create/MultipleCreatePage.tsx
+++ b/src/features/question-multiple/create/MultipleCreatePage.tsx
@@ -50,7 +50,7 @@ export function MultipleCreatePage({
   );
   const [editingChoiceId, setEditingChoiceId] = useState<string | null>(null);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "multiple"; selectedIds: string[] }>({ type: "multiple", selectedIds: [] });
+  const [previewAnswer, setPreviewAnswer] = useState<{ type: "OBJECTIVE"; selectedIds: string[] }>({ type: "OBJECTIVE", selectedIds: [] });
 
   const editingChoice = choices.find((choice) => choice.id === editingChoiceId) ?? null;
   const isCompleteDisabled = questionTitle.trim().length === 0 || choices.length < 2;
@@ -187,7 +187,7 @@ export function MultipleCreatePage({
           <MultipleAnswerPage
             question={{
               id: "preview",
-              type: "multiple",
+              type: "OBJECTIVE",
               data: {
                 title: questionTitle,
                 description: questionDescription,

--- a/src/features/question-scale/answer/ScaleAnswerPage.tsx
+++ b/src/features/question-scale/answer/ScaleAnswerPage.tsx
@@ -8,14 +8,14 @@ export function ScaleAnswerPage({
   question,
   answer,
   onChange,
-}: QuestionAnswerProps<"scale">) {
+}: QuestionAnswerProps<"SCALE">) {
   const { data } = question;
   const selectedValue = answer?.value ?? null;
 
   return (
     <div className="flex flex-col">
       <QuestionHeader
-        categoryLabel={QUESTION_TYPE_LABEL.scale}
+        categoryLabel={QUESTION_TYPE_LABEL.SCALE}
         title={data.title}
         description={data.description}
       />
@@ -41,7 +41,7 @@ export function ScaleAnswerPage({
             <button
               key={value}
               type="button"
-              onClick={() => onChange({ type: "scale", value })}
+              onClick={() => onChange({ type: "SCALE", value })}
               className="flex items-center justify-center bg-transparent border-0 p-0 cursor-pointer"
             >
               <Asset.Text

--- a/src/features/question-scale/create/ScaleCreatePage.tsx
+++ b/src/features/question-scale/create/ScaleCreatePage.tsx
@@ -20,7 +20,7 @@ interface ScaleCreatePageProps {
 export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
-  const existingScale = existing?.typeId === "scale" ? existing : null;
+  const existingScale = existing?.typeId === "SCALE" ? existing : null;
 
   const [questionTitle, setQuestionTitle] = useState(existingScale?.title ?? "");
   const [questionDescription, setQuestionDescription] = useState(existingScale?.description ?? "");
@@ -134,7 +134,7 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
             onCancel={onClose}
             onComplete={() => {
               updateQuestion(questionId, {
-                typeId: "scale",
+                typeId: "SCALE",
                 title: questionTitle,
                 description: questionDescription,
                 scaleCount,

--- a/src/features/question-scale/create/ScaleCreatePage.tsx
+++ b/src/features/question-scale/create/ScaleCreatePage.tsx
@@ -33,7 +33,7 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
   const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "scale"; value: number | null }>({ type: "scale", value: null });
+  const [previewAnswer, setPreviewAnswer] = useState<{ type: "SCALE"; value: number | null }>({ type: "SCALE", value: null });
 
   const { isPhotoSheetOpen, openPhotoSheet, closePhotoSheet, handleCamera, handleAlbum } =
     useQuestionImageUpload(setQuestionImageUrl);
@@ -166,7 +166,7 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
           <ScaleAnswerPage
             question={{
               id: "preview",
-              type: "scale",
+              type: "SCALE",
               data: {
                 title: questionTitle,
                 description: questionDescription,

--- a/src/features/question-subjective/answer/SubjectiveAnswerPage.tsx
+++ b/src/features/question-subjective/answer/SubjectiveAnswerPage.tsx
@@ -2,7 +2,7 @@ import { TextArea } from "@toss/tds-mobile";
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
 import type { QuestionAnswerProps } from "@/features/test-participate/model/types";
 
-type Props = QuestionAnswerProps<"subjective">;
+type Props = QuestionAnswerProps<"SUBJECTIVE">;
 
 export function SubjectiveAnswerPage({ question, answer, onChange }: Props) {
   const { title, description, imageUrl, placeholder, maxLength } =
@@ -35,7 +35,7 @@ export function SubjectiveAnswerPage({ question, answer, onChange }: Props) {
         placeholder={placeholder || "답변을 입력해주세요"}
         height={200}
         maxLength={maxLength ?? undefined}
-        onChange={(e) => onChange({ type: "subjective", text: e.target.value })}
+        onChange={(e) => onChange({ type: "SUBJECTIVE", text: e.target.value })}
       />
     </div>
   );

--- a/src/features/question-subjective/create/SubjectiveCreatePage.tsx
+++ b/src/features/question-subjective/create/SubjectiveCreatePage.tsx
@@ -44,7 +44,7 @@ export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePa
 
   const isCompleteDisabled = questionTitle.trim().length === 0;
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "subjective"; text: string }>({ type: "subjective", text: "" });
+  const [previewAnswer, setPreviewAnswer] = useState<{ type: "SUBJECTIVE"; text: string }>({ type: "SUBJECTIVE", text: "" });
 
   return (
     <motion.div
@@ -149,7 +149,7 @@ export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePa
           <SubjectiveAnswerPage
             question={{
               id: "preview",
-              type: "subjective",
+              type: "SUBJECTIVE",
               data: {
                 title: questionTitle,
                 description: questionDescription,

--- a/src/features/question-subjective/create/SubjectiveCreatePage.tsx
+++ b/src/features/question-subjective/create/SubjectiveCreatePage.tsx
@@ -19,7 +19,7 @@ interface SubjectiveCreatePageProps {
 export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
-  const existingSubjective = existing?.typeId === "subjective" ? existing : null;
+  const existingSubjective = existing?.typeId === "SUBJECTIVE" ? existing : null;
 
   const [questionTitle, setQuestionTitle] = useState(
     existingSubjective?.title ?? "",
@@ -118,7 +118,7 @@ export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePa
             onCancel={onClose}
             onComplete={() => {
               updateQuestion(questionId, {
-                typeId: "subjective",
+                typeId: "SUBJECTIVE",
                 title: questionTitle,
                 description: questionDescription,
                 imageUrl: questionImageUrl,

--- a/src/features/question-tree/answer/TreeAnswerPage.tsx
+++ b/src/features/question-tree/answer/TreeAnswerPage.tsx
@@ -6,7 +6,7 @@ import { QUESTION_TYPE_LABEL } from "@/features/test-participate/model/constants
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
 import type { TreeNodeItem } from "../model/types";
 
-export function TreeAnswerPage({ question, answer, onChange }: QuestionAnswerProps<"tree">) {
+export function TreeAnswerPage({ question, answer, onChange }: QuestionAnswerProps<"TREE_TEST">) {
   const { title, description, nodes } = question.data;
   const selectedNodeId = answer?.selectedNodeId ?? null;
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
@@ -25,7 +25,7 @@ export function TreeAnswerPage({ question, answer, onChange }: QuestionAnswerPro
 
   return (
     <>
-      <QuestionHeader categoryLabel={QUESTION_TYPE_LABEL.tree} title={title} description={description} />
+      <QuestionHeader categoryLabel={QUESTION_TYPE_LABEL.TREE_TEST} title={title} description={description} />
       <div>
         {nodes.map((node) => (
           <TreeNodeRow
@@ -35,7 +35,7 @@ export function TreeAnswerPage({ question, answer, onChange }: QuestionAnswerPro
             expandedIds={expandedIds}
             selectedNodeId={selectedNodeId}
             onToggleExpand={toggleExpanded}
-            onSelect={(nodeId) => onChange({ type: "tree", selectedNodeId: nodeId })}
+            onSelect={(nodeId) => onChange({ type: "TREE_TEST", selectedNodeId: nodeId })}
           />
         ))}
       </div>

--- a/src/features/question-tree/create/TreeCreatePage.tsx
+++ b/src/features/question-tree/create/TreeCreatePage.tsx
@@ -41,7 +41,7 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
   const [isManageMode, setIsManageMode] = useState(false);
   const [nodeSheetMode, setNodeSheetMode] = useState<NodeSheetMode | null>(null);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "tree"; selectedNodeId: string | null }>({ type: "tree", selectedNodeId: null });
+  const [previewAnswer, setPreviewAnswer] = useState<{ type: "TREE_TEST"; selectedNodeId: string | null }>({ type: "TREE_TEST", selectedNodeId: null });
 
   const isCompleteDisabled =
     questionTitle.trim().length === 0 ||
@@ -190,7 +190,7 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
           <TreeAnswerPage
             question={{
               id: "preview",
-              type: "tree",
+              type: "TREE_TEST",
               data: {
                 title: questionTitle,
                 description: questionDescription,

--- a/src/features/question-tree/create/TreeCreatePage.tsx
+++ b/src/features/question-tree/create/TreeCreatePage.tsx
@@ -23,7 +23,7 @@ type NodeSheetMode =
 export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
-  const existingTree = existing?.typeId === "tree" ? existing : null;
+  const existingTree = existing?.typeId === "TREE_TEST" ? existing : null;
 
   const [questionTitle, setQuestionTitle] = useState(
     existingTree?.title ?? "",
@@ -168,7 +168,7 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
             onCancel={onClose}
             onComplete={() => {
               updateQuestion(questionId, {
-                typeId: "tree",
+                typeId: "TREE_TEST",
                 title: questionTitle,
                 description: questionDescription,
                 nodes,

--- a/src/features/test-create/model/types.ts
+++ b/src/features/test-create/model/types.ts
@@ -49,43 +49,43 @@ export interface QuestionType {
 
 export const QUESTION_TYPES = [
   {
-    id: "multiple",
+    id: "OBJECTIVE",
     label: "객관식",
     description: "텍스트/사진 혼합 선택형",
     iconName: "icon-check-circle",
   },
   {
-    id: "subjective",
+    id: "SUBJECTIVE",
     label: "주관식",
     description: "자유 텍스트 입력",
     iconName: "icon-pencil-blue",
   },
   {
-    id: "scale",
+    id: "SCALE",
     label: "척도 질문",
     description: "리커트 척도 평가",
     iconName: "icon-graph-bar-double-short-blue",
   },
   {
-    id: "ab",
+    id: "AB_TEST",
     label: "A/B 테스트",
     description: "두 디자인 분류",
     iconName: "icon-ab-choice",
   },
   {
-    id: "card",
+    id: "CARD_SORTING",
     label: "카드 소팅",
     description: "카테고리 분류",
     iconName: "icon-document-blue",
   },
   {
-    id: "tree",
+    id: "TREE_TEST",
     label: "트리 테스트",
     description: "정보 구조 탐색",
     iconName: "icon-graph-bar-flow-3-cyan",
   },
   {
-    id: "fivesec",
+    id: "FIVE_SECOND",
     label: "5초 테스트",
     description: "짧은 노출 후 기억",
     iconName: "icon-clock-10-hour",
@@ -103,13 +103,13 @@ import type { FivesecQuestionData } from "@/features/question-fivesec/model/type
 import type { CardSortQuestionData } from "@/features/question-cardsort/model/types";
 
 export type QuestionData =
-  | ({ typeId: "multiple" } & MultipleQuestionData)
-  | ({ typeId: "scale" } & ScaleQuestionData)
-  | ({ typeId: "ab" } & AbQuestionData)
-  | ({ typeId: "tree" } & TreeQuestionData)
-  | ({ typeId: "subjective" } & SubjectiveQuestionData)
-  | ({ typeId: "fivesec" } & FivesecQuestionData)
-  | ({ typeId: "card" } & CardSortQuestionData);
+  | ({ typeId: "OBJECTIVE" } & MultipleQuestionData)
+  | ({ typeId: "SCALE" } & ScaleQuestionData)
+  | ({ typeId: "AB_TEST" } & AbQuestionData)
+  | ({ typeId: "TREE_TEST" } & TreeQuestionData)
+  | ({ typeId: "SUBJECTIVE" } & SubjectiveQuestionData)
+  | ({ typeId: "FIVE_SECOND" } & FivesecQuestionData)
+  | ({ typeId: "CARD_SORTING" } & CardSortQuestionData);
 
 export interface PendingQuestion {
   id: string;

--- a/src/features/test-create/model/types.ts
+++ b/src/features/test-create/model/types.ts
@@ -1,4 +1,6 @@
-import { adaptive } from "@toss/tds-colors";
+import { CATEGORIES, MAX_CATEGORIES } from "@/shared/constants/categories";
+export type { Category, CategoryId } from "@/shared/constants/categories";
+export { CATEGORIES, MAX_CATEGORIES };
 
 /** 퍼널 단위 스텝 */
 export const STEPS = [
@@ -37,59 +39,6 @@ export const STEP_PHASE: Record<Step, Phase> = {
 /** 등록 화면에서 수정 가능한 단위 */
 export type EditPhase = "basic" | "service" | "image";
 
-export interface Category {
-  id: string;
-  label: string;
-  iconName: string;
-  iconColor?: string;
-  iconType: "Icon" | "Image";
-}
-
-export const CATEGORIES = [
-  { id: "daily", label: "일상", iconName: "icon-home-garden" },
-  { id: "finance", label: "금융", iconName: "icon-government-blue" },
-  { id: "health", label: "건강", iconName: "icon-arm-muscle-skin" },
-  { id: "shopping", label: "쇼핑", iconName: "icon-shopping-bag-red" },
-  { id: "food", label: "음식", iconName: "icon-tosst-logo" },
-  { id: "game", label: "게임", iconName: "icon-game-dark" },
-  { id: "content", label: "콘텐츠", iconName: "icon-popcorn" },
-  {
-    id: "community",
-    label: "커뮤니티",
-    iconName: "icon-user-nearby-mono",
-    iconColor: adaptive.blue500,
-  },
-  { id: "ai", label: "AI", iconName: "icon-twinkle-graident" },
-  {
-    id: "education",
-    label: "교육",
-    iconName: "https://static.toss.im/2d-emojis/png/4x/u1F4DA.png",
-  },
-  { id: "travel", label: "여행", iconName: "icon-plane-blue500" },
-  {
-    id: "social",
-    label: "소셜",
-    iconName: "icn-earth-line-mono",
-    iconColor: adaptive.teal300,
-  },
-  { id: "convenience", label: "편의", iconName: "icon-u1FA84" },
-  { id: "information", label: "정보", iconName: "icon-search-blue" },
-  {
-    id: "business",
-    label: "비즈니스",
-    iconName: "https://static.toss.im/2d-emojis/png/4x/u1F4BC.png",
-  },
-  { id: "transportation", label: "교통", iconName: "icon-car-red" },
-  {
-    id: "public",
-    label: "공공·행정",
-    iconName: "https://static.toss.im/2d-emojis/png/4x/u1F5C2.png",
-  },
-] as const;
-
-export type CategoryId = (typeof CATEGORIES)[number]["id"];
-
-export const MAX_CATEGORIES = 3;
 
 export interface QuestionType {
   id: string;

--- a/src/features/test-create/model/useSubmitTest.ts
+++ b/src/features/test-create/model/useSubmitTest.ts
@@ -5,7 +5,7 @@ import ky, { HTTPError } from "ky";
 import { createDraft, updateDraft } from "@/shared/api/generated/testDraft";
 import { generateUploadUrl } from "@/shared/api/generated/file";
 import { useTestCreateForm } from "./useTestCreateForm";
-import type { CategoryId, PendingQuestion } from "./types";
+import type { PendingQuestion } from "./types";
 import { ROUTES } from "@/shared/constants/routes";
 
 interface ObjectiveCreateRequest {
@@ -68,15 +68,7 @@ interface FiveSecondCreateRequest {
   options?: { content?: string }[];
 }
 
-type QuestionRequestItem =
-  | ObjectiveCreateRequest
-  | SubjectiveCreateRequest
-  | ScaleCreateRequest
-  | AbTestCreateRequest
-  | CardSortingCreateRequest
-  | TreeTestCreateRequest
-  | FiveSecondCreateRequest;
-
+type QuestionRequestItem = ObjectiveCreateRequest | SubjectiveCreateRequest | ScaleCreateRequest | AbTestCreateRequest | CardSortingCreateRequest | TreeTestCreateRequest | FiveSecondCreateRequest;
 
 function dataUriToBlob(dataUri: string): Blob {
   const [header, base64] = dataUri.split(",");
@@ -116,12 +108,12 @@ async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestIt
   const data = question.data;
 
   switch (data.typeId) {
-    case "multiple": {
+    case "OBJECTIVE": {
       const options = await Promise.all(
         data.choices.map(async (c) => ({
           content: c.name,
           imageKey: await uploadBase64(c.imageUrl || undefined),
-        }))
+        })),
       );
       return {
         type: "OBJECTIVE",
@@ -135,7 +127,7 @@ async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestIt
       } satisfies ObjectiveCreateRequest;
     }
 
-    case "subjective": {
+    case "SUBJECTIVE": {
       const imageKey = await uploadBase64(data.imageUrl || undefined);
       return {
         type: "SUBJECTIVE",
@@ -145,7 +137,7 @@ async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestIt
       } satisfies SubjectiveCreateRequest;
     }
 
-    case "scale": {
+    case "SCALE": {
       const imageKey = await uploadBase64(data.imageUrl || undefined);
       return {
         type: "SCALE",
@@ -158,11 +150,8 @@ async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestIt
       } satisfies ScaleCreateRequest;
     }
 
-    case "ab": {
-      const [aImageKey, bImageKey] = await Promise.all([
-        uploadBase64(data.imageUrlA || undefined),
-        uploadBase64(data.imageUrlB || undefined),
-      ]);
+    case "AB_TEST": {
+      const [aImageKey, bImageKey] = await Promise.all([uploadBase64(data.imageUrlA || undefined), uploadBase64(data.imageUrlB || undefined)]);
       return {
         type: "AB_TEST",
         title: data.title,
@@ -173,7 +162,7 @@ async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestIt
       } satisfies AbTestCreateRequest;
     }
 
-    case "card": {
+    case "CARD_SORTING": {
       return {
         type: "CARD_SORTING",
         title: data.title,
@@ -183,22 +172,23 @@ async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestIt
       } satisfies CardSortingCreateRequest;
     }
 
-    case "tree": {
+    case "TREE_TEST": {
       return {
         type: "TREE_TEST",
         title: data.title,
         description: data.description,
-        features: data.nodes?.map((node) => ({
-          label: node.name,
-          children: node.children?.map((child) => ({
-            label: child.name,
-            children: child.children?.length > 0 ? child.children : undefined,
-          })),
-        })) ?? [],
+        features:
+          data.nodes?.map((node) => ({
+            label: node.name,
+            children: node.children?.map((child) => ({
+              label: child.name,
+              children: child.children?.length > 0 ? child.children : undefined,
+            })),
+          })) ?? [],
       } satisfies TreeTestCreateRequest;
     }
 
-    case "fivesec": {
+    case "FIVE_SECOND": {
       const imageKey = await uploadBase64(data.imageUrl || undefined);
       const isObjective = data.answerType === "multiple";
       return {
@@ -230,9 +220,7 @@ export function useSubmitTest() {
     mutationFn: async () => {
       let imageKeys: string[] = [];
       try {
-        imageKeys = (
-          await Promise.all(form.images.map((img) => uploadBase64(img)))
-        ).filter((k): k is string => !!k);
+        imageKeys = (await Promise.all(form.images.map((img) => uploadBase64(img)))).filter((k): k is string => !!k);
       } catch (e) {
         throw new Error(`[테스트 이미지 업로드 실패] ${e instanceof Error ? e.message : String(e)}`);
       }
@@ -249,9 +237,7 @@ export function useSubmitTest() {
 
       let mappedQuestions: QuestionRequestItem[] = [];
       try {
-        mappedQuestions = (
-          await Promise.all(form.questions.map(mapQuestion))
-        ).filter((q): q is QuestionRequestItem => q !== null);
+        mappedQuestions = (await Promise.all(form.questions.map(mapQuestion))).filter((q): q is QuestionRequestItem => q !== null);
       } catch (e) {
         throw new Error(`[질문 이미지 업로드 실패] ${e instanceof Error ? e.message : String(e)}`);
       }

--- a/src/features/test-create/model/useSubmitTest.ts
+++ b/src/features/test-create/model/useSubmitTest.ts
@@ -3,7 +3,6 @@ import { useNavigate } from "@tanstack/react-router";
 import { useToast } from "@toss/tds-mobile";
 import ky, { HTTPError } from "ky";
 import { createDraft, updateDraft } from "@/shared/api/generated/testDraft";
-import type { TestDraftUpdateRequestCategoriesItem } from "@/shared/api/generated/testDraft";
 import { generateUploadUrl } from "@/shared/api/generated/file";
 import { useTestCreateForm } from "./useTestCreateForm";
 import type { CategoryId, PendingQuestion } from "./types";
@@ -78,25 +77,6 @@ type QuestionRequestItem =
   | TreeTestCreateRequest
   | FiveSecondCreateRequest;
 
-const CATEGORY_MAP: Record<CategoryId, TestDraftUpdateRequestCategoriesItem> = {
-  daily: "DAILY",
-  finance: "FINANCE",
-  health: "HEALTH",
-  shopping: "SHOPPING",
-  food: "FOOD",
-  game: "GAME",
-  content: "CONTENT",
-  community: "COMMUNITY",
-  ai: "AI",
-  education: "EDUCATION",
-  travel: "TRAVEL",
-  social: "SOCIAL",
-  convenience: "CONVENIENCE",
-  information: "INFORMATION",
-  business: "BUSINESS",
-  transportation: "TRANSPORT",
-  public: "PUBLIC_ADMIN",
-};
 
 function dataUriToBlob(dataUri: string): Blob {
   const [header, base64] = dataUri.split(",");
@@ -280,7 +260,7 @@ export function useSubmitTest() {
         await updateDraft(draftId, {
           title: form.name,
           description: form.summary,
-          categories: form.categories.map((c) => CATEGORY_MAP[c]),
+          categories: form.categories,
           serviceName: form.serviceName || undefined,
           serviceDescription: form.description || undefined,
           imageKeys,

--- a/src/features/test-create/model/useSubmitTest.ts
+++ b/src/features/test-create/model/useSubmitTest.ts
@@ -182,7 +182,7 @@ async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestIt
             label: node.name,
             children: node.children?.map((child) => ({
               label: child.name,
-              children: child.children?.length > 0 ? child.children : undefined,
+              children: child.children?.length ? child.children : undefined,
             })),
           })) ?? [],
       } satisfies TreeTestCreateRequest;

--- a/src/features/test-create/ui/TestCreateFunnel.tsx
+++ b/src/features/test-create/ui/TestCreateFunnel.tsx
@@ -326,49 +326,49 @@ export function TestCreateFunnel({ fromPayment = false }: Props) {
         {showGuide && (
           <TestGuidePage key="guide" onClose={() => setShowGuide(false)} />
         )}
-        {activeQuestion?.typeId === "multiple" && (
+        {activeQuestion?.typeId === "OBJECTIVE" && (
           <MultipleCreatePage
             key="question-multiple"
             questionId={activeQuestion.id}
             onClose={() => setActiveQuestion(null)}
           />
         )}
-        {activeQuestion?.typeId === "subjective" && (
+        {activeQuestion?.typeId === "SUBJECTIVE" && (
           <SubjectiveCreatePage
             key="question-subjective"
             questionId={activeQuestion.id}
             onClose={() => setActiveQuestion(null)}
           />
         )}
-        {activeQuestion?.typeId === "scale" && (
+        {activeQuestion?.typeId === "SCALE" && (
           <ScaleCreatePage
             key="question-scale"
             questionId={activeQuestion.id}
             onClose={() => setActiveQuestion(null)}
           />
         )}
-        {activeQuestion?.typeId === "ab" && (
+        {activeQuestion?.typeId === "AB_TEST" && (
           <AbCreatePage
             key="question-ab"
             questionId={activeQuestion.id}
             onClose={() => setActiveQuestion(null)}
           />
         )}
-        {activeQuestion?.typeId === "card" && (
+        {activeQuestion?.typeId === "CARD_SORTING" && (
           <CardSortCreatePage
             key="question-card"
             questionId={activeQuestion.id}
             onClose={() => setActiveQuestion(null)}
           />
         )}
-        {activeQuestion?.typeId === "tree" && (
+        {activeQuestion?.typeId === "TREE_TEST" && (
           <TreeCreatePage
             key="question-tree"
             questionId={activeQuestion.id}
             onClose={() => setActiveQuestion(null)}
           />
         )}
-        {activeQuestion?.typeId === "fivesec" && (
+        {activeQuestion?.typeId === "FIVE_SECOND" && (
           <FivesecCreatePage
             key="question-fivesec"
             questionId={activeQuestion.id}

--- a/src/features/test-participate/model/constants.ts
+++ b/src/features/test-participate/model/constants.ts
@@ -1,21 +1,11 @@
 import type { QuestionType } from "./types";
 
-/**
- * QuestionType → 사용자에게 노출되는 한글 카테고리 레이블 매핑.
- *
- * 각 질문 유형별 UI에서 카테고리 배지 등을 표시할 때 공통으로 사용합니다.
- * UI 컴포넌트마다 중복 정의하지 말고 이 상수를 import 하세요.
- *
- * @example
- * import { QUESTION_TYPE_LABEL } from "../model";
- * const label = QUESTION_TYPE_LABEL[question.type]; // "주관식"
- */
 export const QUESTION_TYPE_LABEL: Record<QuestionType, string> = {
-  subjective: "주관식",
-  multiple: "객관식",
-  tree: "트리 테스트",
-  fivesec: "5초 테스트",
-  scale: "척도 질문",
-  ab: "A/B 테스트",
-  cardsort: "카드 소팅",
+  SUBJECTIVE: "주관식",
+  OBJECTIVE: "객관식",
+  TREE_TEST: "트리 테스트",
+  FIVE_SECOND: "5초 테스트",
+  SCALE: "척도 질문",
+  AB_TEST: "A/B 테스트",
+  CARD_SORTING: "카드 소팅",
 };

--- a/src/features/test-participate/model/mock.ts
+++ b/src/features/test-participate/model/mock.ts
@@ -6,7 +6,7 @@ const MOCK_TEST_1: ParticipateTest = {
   questions: [
     {
       id: "q1",
-      type: "subjective",
+      type: "SUBJECTIVE",
       data: {
         title: "오늘의 기분이 어떤지 작성해주세요",
         description: "좋은 하루 보내셨길 바랍니다",
@@ -17,7 +17,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q2",
-      type: "subjective",
+      type: "SUBJECTIVE",
       data: {
         title: "저녁 뭐 드셨나요?",
         description: "좋은 하루 보내셨길 바랍니다",
@@ -28,7 +28,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q3",
-      type: "tree",
+      type: "TREE_TEST",
       data: {
         title: "내 프로필 사진을 수정하려면 어디로 가야할까요?",
         description: "",
@@ -83,7 +83,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q5",
-      type: "scale",
+      type: "SCALE",
       data: {
         title: "이 서비스가 2030 여성으로서 도움이 되고 편리하다고 느껴지셨나요?",
         description: "1~5점 중에서 생각한 점수를 알려주세요.",
@@ -94,7 +94,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q6",
-      type: "scale",
+      type: "SCALE",
       data: {
         title: "전반적인 만족도를 7점 척도로 평가해주세요.",
         description: "1~7점 중에서 생각한 점수를 알려주세요.",
@@ -105,7 +105,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q7",
-      type: "scale",
+      type: "SCALE",
       data: {
         title: "이 디자인이 브랜드 이미지와 잘 어울린다고 생각하시나요?",
         description: "1~5점 중에서 생각한 점수를 알려주세요.",
@@ -117,7 +117,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q8",
-      type: "ab",
+      type: "AB_TEST",
       data: {
         title: "누가 더 귀엽나요?",
         description: "솔직하게 답변해 주세요",
@@ -127,7 +127,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "cs1",
-      type: "cardsort",
+      type: "CARD_SORTING",
       data: {
         title: "카드를 적절한 카테고리로 분류해주세요",
         description: "각 카드를 하나의 카테고리에 배치해주세요",
@@ -149,7 +149,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q4",
-      type: "multiple",
+      type: "OBJECTIVE",
       data: {
         title: "오늘의 기분이 어떤지 체크해주세요",
         description: "솔직하게 답변해 주세요",
@@ -166,7 +166,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q5",
-      type: "multiple",
+      type: "OBJECTIVE",
       data: {
         title: "선호하는 색상을 모두 골라주세요",
         description: "1개 이상 3개 이하로 선택",
@@ -184,7 +184,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q7",
-      type: "subjective",
+      type: "SUBJECTIVE",
       data: {
         title: "오늘의 기분이 어떤지 작성해주세요",
         description: "좋은 하루 보내셨길 바랍니다",
@@ -195,7 +195,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q8",
-      type: "subjective",
+      type: "SUBJECTIVE",
       data: {
         title: "이 이미지를 보고 느낀 점을 작성해주세요",
         description: "자유롭게 작성해주세요",
@@ -206,7 +206,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q6",
-      type: "fivesec",
+      type: "FIVE_SECOND",
       data: {
         title: "5초 안에 떠오르는 것을 골라주세요",
         description: "1개 이상 2개 이하로 선택",
@@ -228,7 +228,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q9",
-      type: "fivesec",
+      type: "FIVE_SECOND",
       data: {
         title: "이 이미지를 보고 가장 먼저 떠오르는 단어를 선택해주세요",
         description: "1개만 선택",
@@ -251,7 +251,7 @@ const MOCK_TEST_1: ParticipateTest = {
     },
     {
       id: "q10",
-      type: "fivesec",
+      type: "FIVE_SECOND",
       data: {
         title: "사진을 보고 느낀 점을 알려주세요",
         description: "아무거나 다 괜찮아요.",
@@ -277,7 +277,7 @@ const MOCK_TEST_2: ParticipateTest = {
   questions: [
     {
       id: "ab1",
-      type: "ab",
+      type: "AB_TEST",
       data: {
         title: "누가 더 귀엽나요?",
         description: "솔직하게 답변해 주세요",
@@ -287,7 +287,7 @@ const MOCK_TEST_2: ParticipateTest = {
     },
     {
       id: "s1",
-      type: "scale",
+      type: "SCALE",
       data: {
         title: "이 서비스가 전반적으로 사용하기 편리했나요?",
         description: "1~5점 중에서 생각한 점수를 알려주세요.",
@@ -298,7 +298,7 @@ const MOCK_TEST_2: ParticipateTest = {
     },
     {
       id: "s2",
-      type: "scale",
+      type: "SCALE",
       data: {
         title: "이 서비스를 다른 사람에게 추천할 의향이 있나요?",
         description: "1~7점 중에서 생각한 점수를 알려주세요.",
@@ -309,7 +309,7 @@ const MOCK_TEST_2: ParticipateTest = {
     },
     {
       id: "s3",
-      type: "scale",
+      type: "SCALE",
       data: {
         title: "이 디자인이 브랜드 이미지와 잘 어울린다고 생각하시나요?",
         description: "1~5점 중에서 생각한 점수를 알려주세요.",
@@ -321,7 +321,7 @@ const MOCK_TEST_2: ParticipateTest = {
     },
     {
       id: "s4",
-      type: "scale",
+      type: "SCALE",
       data: {
         title: "이 화면 구성이 목적에 맞게 명확하게 전달되나요?",
         description: "1~7점 중에서 생각한 점수를 알려주세요.",
@@ -340,7 +340,7 @@ const MOCK_TEST_3: ParticipateTest = {
   questions: [
     {
       id: "cs1",
-      type: "cardsort",
+      type: "CARD_SORTING",
       data: {
         title: "카드를 적절한 카테고리로 분류해주세요",
         description: "각 카드를 하나의 카테고리에 배치해주세요",
@@ -368,7 +368,7 @@ const MOCK_TEST_3: ParticipateTest = {
     },
     {
       id: "s1",
-      type: "scale",
+      type: "SCALE",
       data: {
         title: "분류 작업이 얼마나 직관적이었나요?",
         description: "1~5점 중에서 생각한 점수를 알려주세요.",
@@ -386,7 +386,7 @@ const MOCK_TEST_4: ParticipateTest = {
   questions: [
     {
       id: "fivesec-multiple",
-      type: "fivesec",
+      type: "FIVE_SECOND",
       data: {
         title: "5초 안에 떠오르는 것을 골라주세요",
         description: "1개 이상 2개 이하로 선택",
@@ -416,7 +416,7 @@ const MOCK_TEST_5: ParticipateTest = {
   questions: [
     {
       id: "fivesec-subjective",
-      type: "fivesec",
+      type: "FIVE_SECOND",
       data: {
         title: "사진을 보고 느낀 점을 알려주세요",
         description: "아무거나 다 괜찮아요.",

--- a/src/features/test-participate/model/types.ts
+++ b/src/features/test-participate/model/types.ts
@@ -9,24 +9,24 @@ import type { CardSortQuestionData } from "@/features/question-cardsort/model/ty
 export type { ScaleQuestionData, AbQuestionData, CardSortQuestionData };
 
 export type ParticipateQuestion =
-  | { id: string; type: "subjective"; data: SubjectiveQuestionData }
-  | { id: string; type: "multiple"; data: MultipleQuestionData }
-  | { id: string; type: "tree"; data: TreeQuestionData }
-  | { id: string; type: "fivesec"; data: FivesecQuestionData }
-  | { id: string; type: "scale"; data: ScaleQuestionData }
-  | { id: string; type: "ab"; data: AbQuestionData }
-  | { id: string; type: "cardsort"; data: CardSortQuestionData };
+  | { id: string; type: "SUBJECTIVE"; data: SubjectiveQuestionData }
+  | { id: string; type: "OBJECTIVE"; data: MultipleQuestionData }
+  | { id: string; type: "TREE_TEST"; data: TreeQuestionData }
+  | { id: string; type: "FIVE_SECOND"; data: FivesecQuestionData }
+  | { id: string; type: "SCALE"; data: ScaleQuestionData }
+  | { id: string; type: "AB_TEST"; data: AbQuestionData }
+  | { id: string; type: "CARD_SORTING"; data: CardSortQuestionData };
 
 export type QuestionType = ParticipateQuestion["type"];
 
 export type Answer =
-  | { type: "subjective"; text: string }
-  | { type: "multiple"; selectedIds: string[]; otherText?: string }
-  | { type: "tree"; selectedNodeId: string | null }
-  | { type: "fivesec"; selectedIds: string[]; text?: string }
-  | { type: "scale"; value: number | null }
-  | { type: "ab"; selected: "A" | "B" | null }
-  | { type: "cardsort"; placements: Record<string, string> };
+  | { type: "SUBJECTIVE"; text: string }
+  | { type: "OBJECTIVE"; selectedIds: string[]; otherText?: string }
+  | { type: "TREE_TEST"; selectedNodeId: string | null }
+  | { type: "FIVE_SECOND"; selectedIds: string[]; text?: string }
+  | { type: "SCALE"; value: number | null }
+  | { type: "AB_TEST"; selected: "A" | "B" | null }
+  | { type: "CARD_SORTING"; placements: Record<string, string> };
 
 export type AnswerOf<T extends QuestionType> = Extract<Answer, { type: T }>;
 

--- a/src/features/test-participate/model/validation.ts
+++ b/src/features/test-participate/model/validation.ts
@@ -4,9 +4,6 @@ export function isAnswerValid(
   question: ParticipateQuestion,
   answer: Answer | undefined,
 ): boolean {
-  // 트리 구현 후 제거
-  if (question.type === "TREE_TEST") return true;
-
   if (!answer || answer.type !== question.type) return false;
 
   switch (question.type) {
@@ -28,10 +25,10 @@ export function isAnswerValid(
       const n = a.selectedIds.length;
       return n >= minSelectCount && n <= maxSelectCount;
     }
-    // case "TREE_TEST": {
-    //   const a = answer as Extract<Answer, { type: "TREE_TEST" }>;
-    //   return a.selectedNodeId !== null;
-    // }
+    case "TREE_TEST": {
+      const a = answer as Extract<Answer, { type: "TREE_TEST" }>;
+      return a.selectedNodeId !== null;
+    }
     case "FIVE_SECOND": {
       const a = answer as Extract<Answer, { type: "FIVE_SECOND" }>;
       if (question.data.answerType === "subjective") {

--- a/src/features/test-participate/model/validation.ts
+++ b/src/features/test-participate/model/validation.ts
@@ -5,13 +5,13 @@ export function isAnswerValid(
   answer: Answer | undefined,
 ): boolean {
   // 트리 구현 후 제거
-  if (question.type === "tree") return true;
+  if (question.type === "TREE_TEST") return true;
 
   if (!answer || answer.type !== question.type) return false;
 
   switch (question.type) {
-    case "subjective": {
-      const a = answer as Extract<Answer, { type: "subjective" }>;
+    case "SUBJECTIVE": {
+      const a = answer as Extract<Answer, { type: "SUBJECTIVE" }>;
       const text = a.text.trim();
       if (text.length === 0) return false;
       if (
@@ -22,18 +22,18 @@ export function isAnswerValid(
       }
       return true;
     }
-    case "multiple": {
-      const a = answer as Extract<Answer, { type: "multiple" }>;
+    case "OBJECTIVE": {
+      const a = answer as Extract<Answer, { type: "OBJECTIVE" }>;
       const { minSelectCount, maxSelectCount } = question.data;
       const n = a.selectedIds.length;
       return n >= minSelectCount && n <= maxSelectCount;
     }
-    // case "tree": {
-    //   const a = answer as Extract<Answer, { type: "tree" }>;
+    // case "TREE_TEST": {
+    //   const a = answer as Extract<Answer, { type: "TREE_TEST" }>;
     //   return a.selectedNodeId !== null;
     // }
-    case "fivesec": {
-      const a = answer as Extract<Answer, { type: "fivesec" }>;
+    case "FIVE_SECOND": {
+      const a = answer as Extract<Answer, { type: "FIVE_SECOND" }>;
       if (question.data.answerType === "subjective") {
         return (a.text ?? "").trim().length > 0;
       }
@@ -41,17 +41,17 @@ export function isAnswerValid(
       const n = a.selectedIds.length;
       return n >= minSelectCount && n <= maxSelectCount;
     }
-    case "scale": {
-      const a = answer as Extract<Answer, { type: "scale" }>;
+    case "SCALE": {
+      const a = answer as Extract<Answer, { type: "SCALE" }>;
       if (a.value === null) return false;
       return a.value >= 1 && a.value <= question.data.scaleCount;
     }
-    case "ab": {
-      const a = answer as Extract<Answer, { type: "ab" }>;
+    case "AB_TEST": {
+      const a = answer as Extract<Answer, { type: "AB_TEST" }>;
       return a.selected !== null;
     }
-    case "cardsort": {
-      const a = answer as Extract<Answer, { type: "cardsort" }>;
+    case "CARD_SORTING": {
+      const a = answer as Extract<Answer, { type: "CARD_SORTING" }>;
       const placedCount = Object.keys(a.placements).length;
       if (question.data.requireAllPlaced) {
         return placedCount === question.data.cards.length;
@@ -63,19 +63,19 @@ export function isAnswerValid(
 
 export function makeEmptyAnswer(question: ParticipateQuestion): Answer {
   switch (question.type) {
-    case "subjective":
-      return { type: "subjective", text: "" };
-    case "multiple":
-      return { type: "multiple", selectedIds: [] };
-    case "tree":
-      return { type: "tree", selectedNodeId: null };
-    case "fivesec":
-      return { type: "fivesec", selectedIds: [] };
-    case "scale":
-      return { type: "scale", value: null };
-    case "ab":
-      return { type: "ab", selected: null };
-    case "cardsort":
-      return { type: "cardsort", placements: {} };
+    case "SUBJECTIVE":
+      return { type: "SUBJECTIVE", text: "" };
+    case "OBJECTIVE":
+      return { type: "OBJECTIVE", selectedIds: [] };
+    case "TREE_TEST":
+      return { type: "TREE_TEST", selectedNodeId: null };
+    case "FIVE_SECOND":
+      return { type: "FIVE_SECOND", selectedIds: [] };
+    case "SCALE":
+      return { type: "SCALE", value: null };
+    case "AB_TEST":
+      return { type: "AB_TEST", selected: null };
+    case "CARD_SORTING":
+      return { type: "CARD_SORTING", placements: {} };
   }
 }

--- a/src/features/test-participate/ui/ParticipatePage.tsx
+++ b/src/features/test-participate/ui/ParticipatePage.tsx
@@ -86,7 +86,7 @@ export function ParticipatePage({ testId }: Props) {
         />
       )}
 
-      {isAbQuestion && currentQuestion.type === "AB_TEST" && (
+      {isAbQuestion && (
         <AbSelectionBottomSheet
           data={currentQuestion.data}
           open={isAbSheetOpen}

--- a/src/features/test-participate/ui/ParticipatePage.tsx
+++ b/src/features/test-participate/ui/ParticipatePage.tsx
@@ -25,8 +25,8 @@ export function ParticipatePage({ testId }: Props) {
   const [isAbSheetOpen, setIsAbSheetOpen] = useState(false);
 
   const progress = (currentIndex + 1) / totalCount;
-  const isAbQuestion = currentQuestion.type === "ab";
-  const isFivesecQuestion = currentQuestion.type === "fivesec";
+  const isAbQuestion = currentQuestion.type === "AB_TEST";
+  const isFivesecQuestion = currentQuestion.type === "FIVE_SECOND";
 
   return (
     <div className="flex flex-col min-h-dvh">
@@ -86,17 +86,17 @@ export function ParticipatePage({ testId }: Props) {
         />
       )}
 
-      {isAbQuestion && currentQuestion.type === "ab" && (
+      {isAbQuestion && currentQuestion.type === "AB_TEST" && (
         <AbSelectionBottomSheet
           data={currentQuestion.data}
           open={isAbSheetOpen}
           onClose={() => setIsAbSheetOpen(false)}
           onConfirm={(selected) => {
             setIsAbSheetOpen(false);
-            funnel.goNextWithAnswer({ type: "ab", selected });
+            funnel.goNextWithAnswer({ type: "AB_TEST", selected });
           }}
           initialSelected={
-            funnel.currentAnswer?.type === "ab" ? funnel.currentAnswer.selected : null
+            funnel.currentAnswer?.type === "AB_TEST" ? funnel.currentAnswer.selected : null
           }
         />
       )}

--- a/src/features/test-participate/ui/QuestionRenderer.tsx
+++ b/src/features/test-participate/ui/QuestionRenderer.tsx
@@ -27,52 +27,52 @@ export function QuestionRenderer({
   isLast,
 }: Props) {
   switch (question.type) {
-    case "scale":
+    case "SCALE":
       return (
         <ScaleAnswerPage
           question={question}
-          answer={answer?.type === "scale" ? answer : undefined}
+          answer={answer?.type === "SCALE" ? answer : undefined}
           onChange={onChange}
         />
       );
-    case "ab":
+    case "AB_TEST":
       return (
         <AbAnswerPage
           question={question}
-          answer={answer?.type === "ab" ? answer : undefined}
+          answer={answer?.type === "AB_TEST" ? answer : undefined}
           onChange={onChange}
         />
       );
-    case "cardsort":
+    case "CARD_SORTING":
       return (
         <CardSortAnswerPage
           question={question}
-          answer={answer?.type === "cardsort" ? answer : undefined}
+          answer={answer?.type === "CARD_SORTING" ? answer : undefined}
           onChange={onChange}
         />
       );
-    case "multiple":
+    case "OBJECTIVE":
       return (
         <MultipleAnswerPage
           question={question}
-          answer={answer?.type === "multiple" ? answer : undefined}
+          answer={answer?.type === "OBJECTIVE" ? answer : undefined}
           onChange={onChange}
         />
       );
-    case "subjective":
+    case "SUBJECTIVE":
       return (
         <SubjectiveAnswerPage
           question={question}
-          answer={answer?.type === "subjective" ? answer : undefined}
+          answer={answer?.type === "SUBJECTIVE" ? answer : undefined}
           onChange={onChange}
         />
       );
-    case "fivesec":
+    case "FIVE_SECOND":
       return (
         <FivesecAnswerPage
           key={question.id}
           question={question}
-          answer={answer?.type === "fivesec" ? answer : undefined}
+          answer={answer?.type === "FIVE_SECOND" ? answer : undefined}
           onChange={onChange}
           onPrev={onPrev ?? (() => {})}
           onGoNext={onGoNext ?? (() => {})}
@@ -80,11 +80,11 @@ export function QuestionRenderer({
           isLast={isLast ?? false}
         />
       );
-    case "tree":
+    case "TREE_TEST":
       return (
         <TreeAnswerPage
           question={question}
-          answer={answer?.type === "tree" ? answer : undefined}
+          answer={answer?.type === "TREE_TEST" ? answer : undefined}
           onChange={onChange}
         />
       );

--- a/src/features/test-result/model/mock.ts
+++ b/src/features/test-result/model/mock.ts
@@ -3,7 +3,7 @@ import type { ParticipateQuestion } from "@/features/test-participate/model/type
 
 export const MOCK_RESULTS: QuestionResult[] = [
   {
-    type: "multiple",
+    type: "OBJECTIVE",
     title: "전반적인 사용 경험에 만족하시나요?",
     options: [
       { label: "프로필", count: 32, percentage: 58, isHighlight: true },
@@ -12,12 +12,12 @@ export const MOCK_RESULTS: QuestionResult[] = [
     ],
   },
   {
-    type: "subjective",
+    type: "SUBJECTIVE",
     title: "전반적인 사용 경험에 만족하시나요?",
     answers: Array(15).fill("만족해요"),
   },
   {
-    type: "scale",
+    type: "SCALE",
     title: "전반적인 사용 경험에 만족하시나요?",
     average: 3.5,
     scores: [
@@ -29,7 +29,7 @@ export const MOCK_RESULTS: QuestionResult[] = [
     ],
   },
   {
-    type: "ab",
+    type: "AB_TEST",
     title: "전반적인 사용 경험에 만족하시나요?",
     options: [
       { label: "A안 (27.2%)", height: 45, isHighlight: false },
@@ -37,7 +37,7 @@ export const MOCK_RESULTS: QuestionResult[] = [
     ],
   },
   {
-    type: "cardSort",
+    type: "CARD_SORTING",
     title: "전반적인 사용 경험에 만족하시나요?",
     categories: [
       {
@@ -65,7 +65,7 @@ export const MOCK_RESULTS: QuestionResult[] = [
     ],
   },
   {
-    type: "tree",
+    type: "TREE_TEST",
     title: "내 프로필을 수정하려면 어디로 가야 할까요?",
     paths: [
       { label: "프로필", count: 32, percentage: 58, isHighlight: true },
@@ -74,7 +74,7 @@ export const MOCK_RESULTS: QuestionResult[] = [
     ],
   },
   {
-    type: "fiveSec",
+    type: "FIVE_SECOND",
     title: "5초동안 보고 기억에 남는것은?",
     imageUrl: undefined,
     answers: [
@@ -100,7 +100,7 @@ export const MOCK_QUESTIONS = [
 export const MOCK_PREVIEW_QUESTIONS: ParticipateQuestion[] = [
   {
     id: "q1",
-    type: "subjective",
+    type: "SUBJECTIVE",
     data: {
       title: "서비스에서 불편한 점은 무엇인가요?",
       description: "자유롭게 작성해주세요",
@@ -111,7 +111,7 @@ export const MOCK_PREVIEW_QUESTIONS: ParticipateQuestion[] = [
   },
   {
     id: "q2",
-    type: "multiple",
+    type: "OBJECTIVE",
     data: {
       title: "자주 사용하는 기능은 무엇인가요?",
       description: "해당하는 항목을 선택해주세요",
@@ -129,7 +129,7 @@ export const MOCK_PREVIEW_QUESTIONS: ParticipateQuestion[] = [
   },
   {
     id: "q3",
-    type: "scale",
+    type: "SCALE",
     data: {
       title: "전반적인 만족도는 어떠신가요?",
       description: "",
@@ -140,7 +140,7 @@ export const MOCK_PREVIEW_QUESTIONS: ParticipateQuestion[] = [
   },
   {
     id: "q4",
-    type: "ab",
+    type: "AB_TEST",
     data: {
       title: "어떤 디자인이 더 마음에 드시나요?",
       description: "두 디자인 중 선호하는 것을 선택해주세요",
@@ -151,7 +151,7 @@ export const MOCK_PREVIEW_QUESTIONS: ParticipateQuestion[] = [
   },
   {
     id: "q5",
-    type: "fivesec",
+    type: "FIVE_SECOND",
     data: {
       title: "화면에서 가장 먼저 눈에 띈 것은?",
       description: "5초 동안 화면을 보고 기억에 남는 것을 선택해주세요",
@@ -173,7 +173,7 @@ export const MOCK_PREVIEW_QUESTIONS: ParticipateQuestion[] = [
   },
   {
     id: "q6",
-    type: "cardsort",
+    type: "CARD_SORTING",
     data: {
       title: "카드를 분류해 주세요",
       description: "각 카드를 알맞은 카테고리에 배치해주세요",
@@ -195,7 +195,7 @@ export const MOCK_PREVIEW_QUESTIONS: ParticipateQuestion[] = [
   },
   {
     id: "q7",
-    type: "tree",
+    type: "TREE_TEST",
     data: {
       title: "고객센터를 찾아보세요",
       description: "메뉴를 탐색해서 원하는 항목을 찾아주세요",

--- a/src/features/test-result/model/types.ts
+++ b/src/features/test-result/model/types.ts
@@ -41,10 +41,10 @@ export interface CardSortCategory {
 }
 
 export type QuestionResult =
-  | { type: "multiple"; title: string; imageUrl?: string; options: MultipleResultOption[] }
-  | { type: "subjective"; title: string; answers: string[] }
-  | { type: "scale"; title: string; average: number; scores: ScoreBar[] }
-  | { type: "ab"; title: string; options: AbOption[] }
-  | { type: "cardSort"; title: string; categories: CardSortCategory[] }
-  | { type: "tree"; title: string; imageUrl?: string; paths: TreeResultPath[] }
-  | { type: "fiveSec"; title: string; imageUrl?: string; answers: FiveSecAnswer[] };
+  | { type: "OBJECTIVE"; title: string; imageUrl?: string; options: MultipleResultOption[] }
+  | { type: "SUBJECTIVE"; title: string; answers: string[] }
+  | { type: "SCALE"; title: string; average: number; scores: ScoreBar[] }
+  | { type: "AB_TEST"; title: string; options: AbOption[] }
+  | { type: "CARD_SORTING"; title: string; categories: CardSortCategory[] }
+  | { type: "TREE_TEST"; title: string; imageUrl?: string; paths: TreeResultPath[] }
+  | { type: "FIVE_SECOND"; title: string; imageUrl?: string; answers: FiveSecAnswer[] };

--- a/src/features/test-result/model/types.ts
+++ b/src/features/test-result/model/types.ts
@@ -35,7 +35,7 @@ export interface CardSortItem {
   isHighlight: boolean;
 }
 
-export interface CardSortCategory {
+export interface CardSortResultCategory {
   name: string;
   items: CardSortItem[];
 }
@@ -45,6 +45,6 @@ export type QuestionResult =
   | { type: "SUBJECTIVE"; title: string; answers: string[] }
   | { type: "SCALE"; title: string; average: number; scores: ScoreBar[] }
   | { type: "AB_TEST"; title: string; options: AbOption[] }
-  | { type: "CARD_SORTING"; title: string; categories: CardSortCategory[] }
+  | { type: "CARD_SORTING"; title: string; categories: CardSortResultCategory[] }
   | { type: "TREE_TEST"; title: string; imageUrl?: string; paths: TreeResultPath[] }
   | { type: "FIVE_SECOND"; title: string; imageUrl?: string; answers: FiveSecAnswer[] };

--- a/src/features/test-result/ui/CardSortResultCard.tsx
+++ b/src/features/test-result/ui/CardSortResultCard.tsx
@@ -2,14 +2,14 @@ import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Asset, IconButton, Text } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
-import type { CardSortCategory, CardSortItem } from "../model/types";
+import type { CardSortResultCategory, CardSortItem } from "../model/types";
 import { ResultCardBase } from "./_shared";
 
-export type { CardSortCategory, CardSortItem };
+export type { CardSortResultCategory, CardSortItem };
 
 interface Props {
   title: string;
-  categories: CardSortCategory[];
+  categories: CardSortResultCategory[];
 }
 
 export function CardSortResultCard({ title, categories }: Props) {

--- a/src/features/test-result/ui/ResultTabContent.tsx
+++ b/src/features/test-result/ui/ResultTabContent.tsx
@@ -15,7 +15,7 @@ export function ResultTabContent() {
       <div className="w-full  p-5 flex flex-col gap-4 items-center">
         {MOCK_RESULTS.map((result, i) => {
           switch (result.type) {
-            case "multiple":
+            case "OBJECTIVE":
               return (
                 <MultipleResultCard
                   key={i}
@@ -24,9 +24,9 @@ export function ResultTabContent() {
                   options={result.options}
                 />
               );
-            case "subjective":
+            case "SUBJECTIVE":
               return <SubjectiveResultCard key={i} title={result.title} answers={result.answers} />;
-            case "scale":
+            case "SCALE":
               return (
                 <ScaleResultCard
                   key={i}
@@ -35,13 +35,13 @@ export function ResultTabContent() {
                   scores={result.scores}
                 />
               );
-            case "ab":
+            case "AB_TEST":
               return <AbResultCard key={i} title={result.title} options={result.options} />;
-            case "cardSort":
+            case "CARD_SORTING":
               return (
                 <CardSortResultCard key={i} title={result.title} categories={result.categories} />
               );
-            case "tree":
+            case "TREE_TEST":
               return (
                 <TreeResultCard
                   key={i}
@@ -50,7 +50,7 @@ export function ResultTabContent() {
                   paths={result.paths}
                 />
               );
-            case "fiveSec":
+            case "FIVE_SECOND":
               return (
                 <FiveSecResultCard
                   key={i}

--- a/src/features/test-result/ui/TestResultPage.tsx
+++ b/src/features/test-result/ui/TestResultPage.tsx
@@ -54,11 +54,11 @@ function FivesecPreviewOverlay({
   question,
   onClose,
 }: {
-  question: Extract<ParticipateQuestion, { type: "fivesec" }>;
+  question: Extract<ParticipateQuestion, { type: "FIVE_SECOND" }>;
   onClose: () => void;
 }) {
-  const [answer, setAnswer] = useState<{ type: "fivesec"; selectedIds: string[] }>({
-    type: "fivesec",
+  const [answer, setAnswer] = useState<{ type: "FIVE_SECOND"; selectedIds: string[] }>({
+    type: "FIVE_SECOND",
     selectedIds: [],
   });
 

--- a/src/features/test-result/ui/index.ts
+++ b/src/features/test-result/ui/index.ts
@@ -16,5 +16,5 @@ export type {
   ScoreBar,
   AbOption,
   CardSortItem,
-  CardSortCategory,
+  CardSortResultCategory,
 } from "../model/types";

--- a/src/shared/constants/categories.ts
+++ b/src/shared/constants/categories.ts
@@ -1,0 +1,36 @@
+import { adaptive } from "@toss/tds-colors";
+
+export interface Category {
+  id: string;
+  label: string;
+  iconName: string;
+  iconColor?: string;
+}
+
+export const CATEGORIES = [
+  { id: "DAILY", label: "일상", iconName: "icon-home-garden" },
+  { id: "FINANCE", label: "금융", iconName: "icon-government-blue" },
+  { id: "HEALTH", label: "건강", iconName: "icon-arm-muscle-skin" },
+  { id: "SHOPPING", label: "쇼핑", iconName: "icon-shopping-bag-red" },
+  { id: "FOOD", label: "음식", iconName: "icon-tosst-logo" },
+  { id: "GAME", label: "게임", iconName: "icon-game-dark" },
+  { id: "CONTENT", label: "콘텐츠", iconName: "icon-popcorn" },
+  { id: "COMMUNITY", label: "커뮤니티", iconName: "icon-user-nearby-mono", iconColor: adaptive.blue500 },
+  { id: "AI", label: "AI", iconName: "icon-twinkle-graident" },
+  { id: "EDUCATION", label: "교육", iconName: "https://static.toss.im/2d-emojis/png/4x/u1F4DA.png" },
+  { id: "TRAVEL", label: "여행", iconName: "icon-plane-blue500" },
+  { id: "SOCIAL", label: "소셜", iconName: "icn-earth-line-mono", iconColor: adaptive.teal300 },
+  { id: "CONVENIENCE", label: "편의", iconName: "icon-u1FA84" },
+  { id: "INFORMATION", label: "정보", iconName: "icon-search-blue" },
+  { id: "BUSINESS", label: "비즈니스", iconName: "https://static.toss.im/2d-emojis/png/4x/u1F4BC.png" },
+  { id: "TRANSPORT", label: "교통", iconName: "icon-car-red" },
+  { id: "PUBLIC_ADMIN", label: "공공·행정", iconName: "https://static.toss.im/2d-emojis/png/4x/u1F5C2.png" },
+] as const;
+
+export type CategoryId = (typeof CATEGORIES)[number]["id"];
+
+export const MAX_CATEGORIES = 3;
+
+export const CATEGORY_LABEL: Record<string, string> = Object.fromEntries(
+  CATEGORIES.map((c) => [c.id, c.label])
+);

--- a/src/shared/constants/imageRatio.ts
+++ b/src/shared/constants/imageRatio.ts
@@ -1,0 +1,7 @@
+export type AbRatio = "9:16" | "1:1" | "4:3";
+
+export const RATIO_TO_CSS: Record<AbRatio, string> = {
+  "9:16": "9/16",
+  "1:1": "1/1",
+  "4:3": "4/3",
+};


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [x] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #89

## 👩🏻‍💻 작업 사항

- 질문 타입 ID를 API 스펙 enum 값으로 전면 통일 (`"fivesec"` → `"FIVE_SECOND"`, `"multiple"` → `"OBJECTIVE"` 등) — test-participate, test-create, answer/create 페이지, test-result 전체 반영
- 카테고리 상수를 `shared/constants/categories.ts`로 통합, API 대문자 ID 기준으로 통일
- `RATIO_TO_CSS` / `AbRatio`를 `shared/constants/imageRatio.ts`로 이동하여 FSD 위반 해소
- `CardSortCategory` → `CardSortResultCategory` 리네임 (question-cardsort와 이름 충돌 방지)
- 트리 테스트 답변 검증 로직 활성화

## 📢 기타(공유 사항)

- `test-create`의 내부 `typeId`도 API enum 값으로 통일되어 변환 로직이 완전히 제거됨
- `answerType: "multiple" | "subjective"` (FivesecQuestionData 데이터 필드)는 API 스펙과 무관하므로 변경하지 않음