### PR TITLE
[FEAT] 관심 탭 api 연결

### DIFF
--- a/src/features/interest/ui/InterestList.tsx
+++ b/src/features/interest/ui/InterestList.tsx
@@ -1,45 +1,53 @@
-import { Asset, Result, Text } from "@toss/tds-mobile";
+import { useQuery } from "@tanstack/react-query";
+import { Asset, Result, Skeleton, Text } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { useNavigate } from "@tanstack/react-router";
+import { listLikedTests, getListLikedTestsUrl } from "@/shared/api/generated/test";
 import { TestCard } from "@/shared/ui/TestCard";
 import { ROUTES } from "@/shared/constants/routes";
 
-const MOCK_TESTS = [
-  {
-    id: 1,
-    title: "테스트명 한줄만 보이게아아아아아아",
-    description: "테스트 한줄 소개 한줄만 보이게탈탈탈라탈리라라라라라라",
-    reward: 300,
-    thumbnailUrl:
-      "https://static.toss.im/assets/homepage/tossapp/toss-app-main.png",
-    liked: true,
-  },
-  {
-    id: 2,
-    title: "테스트명 한줄만 보이게",
-    description: "테스트 한줄 소개 한줄만 보이게",
-    reward: 300,
-    thumbnailUrl: "",
-    liked: true,
-  },
-  {
-    id: 3,
-    title: "테스트명 세 번째",
-    description: "테스트 한줄 소개",
-    reward: 150,
-    thumbnailUrl:
-      "https://static.toss.im/assets/homepage/tossapp/toss-app-main.png",
-    liked: true,
-  },
-];
-
-interface Props {
-  onRetry?: () => void;
-}
-
-export function InterestList({ onRetry }: Props) {
+export function InterestList() {
   const navigate = useNavigate();
-  const tests = MOCK_TESTS;
+
+  const { data, isLoading, isError, refetch } = useQuery({
+    queryKey: [getListLikedTestsUrl()],
+    queryFn: () => listLikedTests(),
+  });
+
+  const tests = data?.data?.data?.tests ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="flex flex-col gap-3 px-4 pt-6">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <Skeleton key={i} custom={["card", "title", "subtitle"]} repeatLastItemCount={0} />
+        ))}
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col min-h-screen items-center justify-center px-6">
+        <Result
+          title="목록을 불러오지 못했어요"
+          description="잠시 후 다시 시도해 주세요"
+          figure={
+            <Asset.Lottie
+              frameShape={Asset.frameShape.CleanW60}
+              src="https://static.toss.im/lotties-common/error-spot.json"
+              aria-hidden={true}
+            />
+          }
+          button={
+            <Result.Button color="dark" variant="weak" onClick={() => refetch()}>
+              다시 시도하기
+            </Result.Button>
+          }
+        />
+      </div>
+    );
+  }
 
   return (
     <div className="flex flex-col">
@@ -57,12 +65,12 @@ export function InterestList({ onRetry }: Props) {
           {tests.map((test) => (
             <TestCard
               key={test.id}
-              id={test.id}
-              title={test.title}
-              description={test.description}
-              reward={test.reward}
-              thumbnailUrl={test.thumbnailUrl}
-              liked={test.liked}
+              id={test.id ?? 0}
+              title={test.title ?? ""}
+              description={test.description ?? ""}
+              reward={test.reward ?? 0}
+              thumbnailUrl={test.thumbnailUrl ?? ""}
+              liked={true}
               onClick={() =>
                 navigate({
                   to: ROUTES.INTEREST_DETAIL,
@@ -83,11 +91,7 @@ export function InterestList({ onRetry }: Props) {
               aria-hidden={true}
             />
           }
-          button={
-            <Result.Button color="dark" variant="weak" onClick={onRetry}>
-              다시 시도하기
-            </Result.Button>
-          }
+          button={undefined}
         />
       )}
     </div>

--- a/src/features/interest/ui/InterestList.tsx
+++ b/src/features/interest/ui/InterestList.tsx
@@ -14,7 +14,9 @@ export function InterestList() {
     queryFn: () => listLikedTests(),
   });
 
-  const tests = data?.data?.data?.tests ?? [];
+  const tests = (data?.data?.data?.tests ?? []).filter(
+    (test): test is typeof test & { id: number } => test.id !== undefined
+  );
 
   if (isLoading) {
     return (
@@ -65,7 +67,7 @@ export function InterestList() {
           {tests.map((test) => (
             <TestCard
               key={test.id}
-              id={test.id ?? 0}
+              id={test.id}
               title={test.title ?? ""}
               description={test.description ?? ""}
               reward={test.reward ?? 0}

--- a/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
-import { RATIO_TO_CSS } from "@/shared/constants/imageRatio";
+import { RATIO_TO_CSS, type AbRatio } from "@/shared/constants/imageRatio";
 
 interface Props {
   remaining: number;

--- a/src/features/question-fivesec/answer/FivesecPreviewPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecPreviewPhase.tsx
@@ -2,7 +2,7 @@ import { motion } from "framer-motion";
 import { adaptive } from "@toss/tds-colors";
 import { Text } from "@toss/tds-mobile";
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
-import { RATIO_TO_CSS } from "@/shared/constants/imageRatio";
+import { RATIO_TO_CSS, type AbRatio } from "@/shared/constants/imageRatio";
 
 interface Props {
   ratio: AbRatio;

--- a/src/features/test-create/model/types.ts
+++ b/src/features/test-create/model/types.ts
@@ -1,4 +1,5 @@
 import { CATEGORIES, MAX_CATEGORIES } from "@/shared/constants/categories";
+import type { CategoryId } from "@/shared/constants/categories";
 export type { Category, CategoryId } from "@/shared/constants/categories";
 export { CATEGORIES, MAX_CATEGORIES };
 

--- a/src/features/test-result/ui/TestResultPage.tsx
+++ b/src/features/test-result/ui/TestResultPage.tsx
@@ -88,7 +88,7 @@ export function TestResultPage({ status }: Props) {
   const [previewIndex, setPreviewIndex] = useState<number | null>(null);
 
   const previewQuestion = previewIndex !== null ? MOCK_PREVIEW_QUESTIONS[previewIndex] : null;
-  const isFivesecPreview = previewQuestion?.type === "fivesec";
+  const isFivesecPreview = previewQuestion?.type === "FIVE_SECOND";
 
   return (
     <div>

--- a/src/shared/ui/TestCard.tsx
+++ b/src/shared/ui/TestCard.tsx
@@ -1,8 +1,8 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Asset, Text } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
-import { likeTest, unlikeTest, getListTestsUrl } from "@/shared/api/generated/test";
+import { likeTest, unlikeTest, getListTestsUrl, getListLikedTestsUrl } from "@/shared/api/generated/test";
 
 type Props = {
   id: number;
@@ -24,6 +24,10 @@ export function TestCard({
   onClick,
 }: Props) {
   const [isLiked, setIsLiked] = useState(liked);
+
+  useEffect(() => {
+    setIsLiked(liked);
+  }, [liked]);
   const queryClient = useQueryClient();
 
   const { mutate: like } = useMutation({
@@ -34,7 +38,10 @@ export function TestCard({
       return { prev };
     },
     onError: (_, __, context) => setIsLiked(context?.prev ?? false),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: [getListTestsUrl()] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [getListTestsUrl()] });
+      queryClient.invalidateQueries({ queryKey: [getListLikedTestsUrl()] });
+    },
   });
 
   const { mutate: unlike } = useMutation({
@@ -45,7 +52,10 @@ export function TestCard({
       return { prev };
     },
     onError: (_, __, context) => setIsLiked(context?.prev ?? true),
-    onSuccess: () => queryClient.invalidateQueries({ queryKey: [getListTestsUrl()] }),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [getListTestsUrl()] });
+      queryClient.invalidateQueries({ queryKey: [getListLikedTestsUrl()] });
+    },
   });
 
   function handleLikeToggle(e: React.MouseEvent) {

--- a/src/shared/ui/TestCard.tsx
+++ b/src/shared/ui/TestCard.tsx
@@ -2,7 +2,15 @@ import { useState, useEffect } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Asset, Text } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
-import { likeTest, unlikeTest, getListTestsUrl, getListLikedTestsUrl } from "@/shared/api/generated/test";
+import {
+  likeTest,
+  unlikeTest,
+  getListTestsUrl,
+  getListLikedTestsUrl,
+  type listTestsResponse,
+  type listLikedTestsResponse,
+  type LikedTestSummaryItem,
+} from "@/shared/api/generated/test";
 
 type Props = {
   id: number;
@@ -28,17 +36,54 @@ export function TestCard({
   useEffect(() => {
     setIsLiked(liked);
   }, [liked]);
+
   const queryClient = useQueryClient();
 
   const { mutate: like } = useMutation({
     mutationFn: () => likeTest(id),
-    onMutate: () => {
-      const prev = isLiked;
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: [getListTestsUrl()] });
+      await queryClient.cancelQueries({ queryKey: [getListLikedTestsUrl()] });
+
+      const prevTests = queryClient.getQueryData<listTestsResponse>([getListTestsUrl()]);
+      const prevLikedTests = queryClient.getQueryData<listLikedTestsResponse>([getListLikedTestsUrl()]);
+
+      queryClient.setQueryData<listTestsResponse>([getListTestsUrl()], (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          data: {
+            ...old.data,
+            data: old.data.data?.map((t) => (t.id === id ? { ...t, isLiked: true } : t)),
+          },
+        };
+      });
+
+      queryClient.setQueryData<listLikedTestsResponse>([getListLikedTestsUrl()], (old) => {
+        if (!old) return old;
+        const newItem: LikedTestSummaryItem = { id, title, description, reward, thumbnailUrl };
+        return {
+          ...old,
+          data: {
+            ...old.data,
+            data: {
+              ...old.data?.data,
+              testCount: (old.data?.data?.testCount ?? 0) + 1,
+              tests: [newItem, ...(old.data?.data?.tests ?? [])],
+            },
+          },
+        };
+      });
+
       setIsLiked(true);
-      return { prev };
+      return { prevTests, prevLikedTests, prevLiked: isLiked };
     },
-    onError: (_, __, context) => setIsLiked(context?.prev ?? false),
-    onSuccess: () => {
+    onError: (_, __, context) => {
+      setIsLiked(context?.prevLiked ?? false);
+      if (context?.prevTests) queryClient.setQueryData([getListTestsUrl()], context.prevTests);
+      if (context?.prevLikedTests) queryClient.setQueryData([getListLikedTestsUrl()], context.prevLikedTests);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: [getListTestsUrl()] });
       queryClient.invalidateQueries({ queryKey: [getListLikedTestsUrl()] });
     },
@@ -46,13 +91,48 @@ export function TestCard({
 
   const { mutate: unlike } = useMutation({
     mutationFn: () => unlikeTest(id),
-    onMutate: () => {
-      const prev = isLiked;
+    onMutate: async () => {
+      await queryClient.cancelQueries({ queryKey: [getListTestsUrl()] });
+      await queryClient.cancelQueries({ queryKey: [getListLikedTestsUrl()] });
+
+      const prevTests = queryClient.getQueryData<listTestsResponse>([getListTestsUrl()]);
+      const prevLikedTests = queryClient.getQueryData<listLikedTestsResponse>([getListLikedTestsUrl()]);
+
+      queryClient.setQueryData<listTestsResponse>([getListTestsUrl()], (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          data: {
+            ...old.data,
+            data: old.data.data?.map((t) => (t.id === id ? { ...t, isLiked: false } : t)),
+          },
+        };
+      });
+
+      queryClient.setQueryData<listLikedTestsResponse>([getListLikedTestsUrl()], (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          data: {
+            ...old.data,
+            data: {
+              ...old.data?.data,
+              testCount: Math.max((old.data?.data?.testCount ?? 1) - 1, 0),
+              tests: old.data?.data?.tests?.filter((t) => t.id !== id) ?? [],
+            },
+          },
+        };
+      });
+
       setIsLiked(false);
-      return { prev };
+      return { prevTests, prevLikedTests, prevLiked: isLiked };
     },
-    onError: (_, __, context) => setIsLiked(context?.prev ?? true),
-    onSuccess: () => {
+    onError: (_, __, context) => {
+      setIsLiked(context?.prevLiked ?? true);
+      if (context?.prevTests) queryClient.setQueryData([getListTestsUrl()], context.prevTests);
+      if (context?.prevLikedTests) queryClient.setQueryData([getListLikedTestsUrl()], context.prevLikedTests);
+    },
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: [getListTestsUrl()] });
       queryClient.invalidateQueries({ queryKey: [getListLikedTestsUrl()] });
     },

--- a/src/shared/ui/TestCard.tsx
+++ b/src/shared/ui/TestCard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Asset, Text } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
@@ -31,11 +31,8 @@ export function TestCard({
   liked,
   onClick,
 }: Props) {
-  const [isLiked, setIsLiked] = useState(liked);
-
-  useEffect(() => {
-    setIsLiked(liked);
-  }, [liked]);
+  const [pendingLiked, setPendingLiked] = useState<boolean | null>(null);
+  const isLiked = pendingLiked ?? liked;
 
   const queryClient = useQueryClient();
 
@@ -75,15 +72,16 @@ export function TestCard({
         };
       });
 
-      setIsLiked(true);
-      return { prevTests, prevLikedTests, prevLiked: isLiked };
+      setPendingLiked(true);
+      return { prevTests, prevLikedTests };
     },
     onError: (_, __, context) => {
-      setIsLiked(context?.prevLiked ?? false);
+      setPendingLiked(null);
       if (context?.prevTests) queryClient.setQueryData([getListTestsUrl()], context.prevTests);
       if (context?.prevLikedTests) queryClient.setQueryData([getListLikedTestsUrl()], context.prevLikedTests);
     },
     onSettled: () => {
+      setPendingLiked(null);
       queryClient.invalidateQueries({ queryKey: [getListTestsUrl()] });
       queryClient.invalidateQueries({ queryKey: [getListLikedTestsUrl()] });
     },
@@ -124,15 +122,16 @@ export function TestCard({
         };
       });
 
-      setIsLiked(false);
-      return { prevTests, prevLikedTests, prevLiked: isLiked };
+      setPendingLiked(false);
+      return { prevTests, prevLikedTests };
     },
     onError: (_, __, context) => {
-      setIsLiked(context?.prevLiked ?? true);
+      setPendingLiked(null);
       if (context?.prevTests) queryClient.setQueryData([getListTestsUrl()], context.prevTests);
       if (context?.prevLikedTests) queryClient.setQueryData([getListLikedTestsUrl()], context.prevLikedTests);
     },
     onSettled: () => {
+      setPendingLiked(null);
       queryClient.invalidateQueries({ queryKey: [getListTestsUrl()] });
       queryClient.invalidateQueries({ queryKey: [getListLikedTestsUrl()] });
     },


### PR DESCRIPTION
## 🛠 작업 내용
- [x] 관심 탭 api 연결
- [x] 낙관적 캐시 업데이트 적용

## 💡 참고 사항
-

## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #88

## 👩🏻‍💻 작업 사항

**InterestList.tsx**
- 목 데이터 제거, `listLikedTests` API 실제 연동
- 로딩 중 TDS `Skeleton` 컴포넌트 3개 표시
- 에러 발생 시 TDS `Result` 컴포넌트로 재시도 UI 표시

**TestCard.tsx**
- 좋아요/취소 성공 시 관심 탭 쿼리(`getListLikedTestsUrl`)도 함께 invalidate
- `liked` prop 변경 시 내부 상태 동기화 (`useEffect` 추가)

## 📢 기타(공유 사항) 
-