### PR TITLE
[FIX] 발견 탭 테스트 목록 데이터 파싱 문제 해결

### DIFF
--- a/src/routes/discovery/index.tsx
+++ b/src/routes/discovery/index.tsx
@@ -14,7 +14,9 @@ function HomePage() {
     queryFn: listTests,
   });
 
-  const tests = (data?.data.data ?? []).map((item) => ({
+  type TestsPayload = { testCount?: number; tests?: { id?: number; title?: string; description?: string; reward?: number; thumbnailUrl?: string; isLiked?: boolean }[] };
+  const rawTests = (data?.data?.data as TestsPayload | undefined)?.tests;
+  const tests = (Array.isArray(rawTests) ? rawTests : []).map((item) => ({
     id: item.id ?? 0,
     title: item.title ?? "",
     description: item.description ?? "",


### PR DESCRIPTION
## Summary
- `data?.data.data` 파싱 방식을 `data?.data?.data.tests` 구조에 맞게 수정
- API 응답 타입을 `TestsPayload`로 명시하여 타입 안정성 향상
- 배열 여부 체크(`Array.isArray`) 추가로 런타임 오류 방지

## Test plan
- [ ] 발견 탭 진입 시 테스트 목록이 정상 렌더링되는지 확인
- [ ] 빈 응답 시 빈 화면 처리 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)