### PR TITLE
[FEAT] 테스트 등록 + 결제 api 연동

### DIFF
--- a/src/features/test-create/model/useSubmitTest.ts
+++ b/src/features/test-create/model/useSubmitTest.ts
@@ -253,7 +253,7 @@ export function useSubmitTest(draftId: number | undefined) {
       return draftId;
     },
     onSuccess: (draftId) => {
-      navigate({ to: ROUTES.TEST_PAYMENT, search: { draftId } });
+      navigate({ to: ROUTES.TEST_PAYMENT, search: { draftId }, replace: true });
     },
     onError: async (error) => {
       let message = `실패: ${String(error)}`;

--- a/src/features/test-create/model/useSubmitTest.ts
+++ b/src/features/test-create/model/useSubmitTest.ts
@@ -2,7 +2,7 @@ import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useToast } from "@toss/tds-mobile";
 import ky, { HTTPError } from "ky";
-import { createDraft, updateDraft } from "@/shared/api/generated/testDraft";
+import { updateDraft } from "@/shared/api/generated/testDraft";
 import { generateUploadUrl } from "@/shared/api/generated/file";
 import { useTestCreateForm } from "./useTestCreateForm";
 import type { PendingQuestion } from "./types";
@@ -211,28 +211,20 @@ async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestIt
   }
 }
 
-export function useSubmitTest() {
+export function useSubmitTest(draftId: number | undefined) {
   const navigate = useNavigate();
   const form = useTestCreateForm();
   const { openToast } = useToast();
 
   return useMutation({
     mutationFn: async () => {
+      if (!draftId) throw new Error("드래프트 ID가 없습니다. 처음부터 다시 시도해주세요.");
+
       let imageKeys: string[] = [];
       try {
         imageKeys = (await Promise.all(form.images.map((img) => uploadBase64(img)))).filter((k): k is string => !!k);
       } catch (e) {
         throw new Error(`[테스트 이미지 업로드 실패] ${e instanceof Error ? e.message : String(e)}`);
-      }
-
-      let draftId: number;
-      try {
-        const draftResponse = await createDraft();
-        const id = draftResponse.data.data?.draftId;
-        if (!id) throw new Error("드래프트 ID를 받지 못했습니다.");
-        draftId = id;
-      } catch (e) {
-        throw new Error(`[테스트 초안 생성 실패] ${e instanceof Error ? e.message : String(e)}`);
       }
 
       let mappedQuestions: QuestionRequestItem[] = [];
@@ -258,9 +250,9 @@ export function useSubmitTest() {
 
       return draftId;
     },
-    onSuccess: () => {
+    onSuccess: (draftId) => {
       form.reset();
-      navigate({ to: ROUTES.TEST_PAYMENT });
+      navigate({ to: ROUTES.TEST_PAYMENT, search: { draftId } });
     },
     onError: async (error) => {
       let message = `실패: ${String(error)}`;

--- a/src/features/test-create/model/useSubmitTest.ts
+++ b/src/features/test-create/model/useSubmitTest.ts
@@ -6,6 +6,7 @@ import { updateDraft } from "@/shared/api/generated/testDraft";
 import { generateUploadUrl } from "@/shared/api/generated/file";
 import { useTestCreateForm } from "./useTestCreateForm";
 import type { PendingQuestion } from "./types";
+import type { TreeNodeItem } from "@/features/question-tree/model/types";
 import { ROUTES } from "@/shared/constants/routes";
 
 interface ObjectiveCreateRequest {
@@ -48,11 +49,15 @@ interface CardSortingCreateRequest {
   cards?: string[];
   categories?: string[];
 }
+interface TreeFeatureNode {
+  label: string;
+  children: TreeFeatureNode[];
+}
 interface TreeTestCreateRequest {
   type: "TREE_TEST";
   title?: string;
   description?: string;
-  features?: unknown[];
+  features?: TreeFeatureNode[];
 }
 interface FiveSecondCreateRequest {
   type: "FIVE_SECOND";
@@ -173,18 +178,15 @@ async function mapQuestion(question: PendingQuestion): Promise<QuestionRequestIt
     }
 
     case "TREE_TEST": {
+      const toFeatureNode = (node: TreeNodeItem): TreeFeatureNode => ({
+        label: node.name,
+        children: node.children?.map(toFeatureNode) ?? [],
+      });
       return {
         type: "TREE_TEST",
         title: data.title,
         description: data.description,
-        features:
-          data.nodes?.map((node) => ({
-            label: node.name,
-            children: node.children?.map((child) => ({
-              label: child.name,
-              children: child.children?.length ? child.children : undefined,
-            })),
-          })) ?? [],
+        features: data.nodes?.map(toFeatureNode) ?? [],
       } satisfies TreeTestCreateRequest;
     }
 

--- a/src/features/test-create/model/useSubmitTest.ts
+++ b/src/features/test-create/model/useSubmitTest.ts
@@ -251,7 +251,6 @@ export function useSubmitTest(draftId: number | undefined) {
       return draftId;
     },
     onSuccess: (draftId) => {
-      form.reset();
       navigate({ to: ROUTES.TEST_PAYMENT, search: { draftId } });
     },
     onError: async (error) => {

--- a/src/features/test-create/ui/QuestionManageSheet.tsx
+++ b/src/features/test-create/ui/QuestionManageSheet.tsx
@@ -135,7 +135,7 @@ export function QuestionManageSheet({ questions, onDelete, onReorder, onSave, on
           </CTAButton>
         }
         rightButton={
-          <CTAButton className="w-full" disabled={questions.length === 0} onClick={() => setIsSaveDialogOpen(true)}>
+          <CTAButton className="w-full" onClick={() => setIsSaveDialogOpen(true)}>
             저장하기
           </CTAButton>
         }

--- a/src/features/test-create/ui/TestCreateFunnel.tsx
+++ b/src/features/test-create/ui/TestCreateFunnel.tsx
@@ -17,6 +17,7 @@ import { ServiceDescriptionEditPage } from "./ServiceDescriptionEditPage";
 import { TestImageEditPage } from "./TestImageEditPage";
 import { useFunnel } from "../model/useFunnel";
 import { useTestCreateForm } from "../model/useTestCreateForm";
+import { useSubmitTest } from "../model/useSubmitTest";
 import type { BasicSubStep, EditPhase, QuestionTypeId } from "../model/types";
 import { ROUTES } from "@/shared/constants/routes";
 import { MultipleCreatePage } from "@/features/question-multiple/create";
@@ -28,10 +29,11 @@ import { FivesecCreatePage } from "@/features/question-fivesec/create";
 import { CardSortCreatePage } from "@/features/question-cardsort/create";
 
 interface Props {
+  draftId?: number;
   fromPayment?: boolean;
 }
 
-export function TestCreateFunnel({ fromPayment = false }: Props) {
+export function TestCreateFunnel({ draftId, fromPayment = false }: Props) {
   const navigate = useNavigate();
   const funnel = useFunnel(fromPayment ? "register" : "basic");
   const form = useTestCreateForm();
@@ -51,6 +53,7 @@ export function TestCreateFunnel({ fromPayment = false }: Props) {
     typeId: QuestionTypeId;
   } | null>(null);
   const [isExitDialogOpen, setIsExitDialogOpen] = useState(false);
+  const { mutate: submitTest, isPending: isSubmitting } = useSubmitTest(draftId);
   const [showGuide, setShowGuide] = useState(false);
   const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const exitUnsubscribeRef = useRef<(() => void) | null>(null);
@@ -205,7 +208,7 @@ export function TestCreateFunnel({ fromPayment = false }: Props) {
             funnel.prev();
           }
         }}
-        onSubmit={() => navigate({ to: ROUTES.TEST_PAYMENT })}
+        onSubmit={() => submitTest()}
         currentStep={funnel.step}
         ctaMode={ctaMode}
         isConfirmDisabled={isConfirmDisabled}
@@ -223,7 +226,7 @@ export function TestCreateFunnel({ fromPayment = false }: Props) {
               ? "이전"
               : "취소"
         }
-        isSubmitDisabled={!isAllComplete || !form.questions.some((q) => !!q.data)}
+        isSubmitDisabled={!isAllComplete || !form.questions.some((q) => !!q.data) || isSubmitting}
         submitLabel="테스트 만들기"
       >
         {funnel.step === "register" ? (

--- a/src/features/test-payment/model/usePaymentSubmit.ts
+++ b/src/features/test-payment/model/usePaymentSubmit.ts
@@ -1,15 +1,28 @@
 import { useMutation } from "@tanstack/react-query";
 import { useNavigate } from "@tanstack/react-router";
 import { useToast } from "@toss/tds-mobile";
-import { updateDraft } from "@/shared/api/generated/testDraft";
+import { HTTPError } from "ky";
+import { updateDraft, getDraft } from "@/shared/api/generated/testDraft";
 import { createPayment, executePayment } from "@/shared/api/generated/payment";
 import { ROUTES } from "@/shared/constants/routes";
 import type { TesterCount, RewardAmount } from "./types";
+
+async function stepError(label: string, e: unknown): Promise<Error> {
+  let detail = e instanceof Error ? e.message : String(e);
+  if (e instanceof HTTPError) {
+    try {
+      const body = await e.response.json() as { code?: string; message?: string };
+      detail = `${e.response.status} ${body.code ?? ""} ${body.message ?? ""}`.trim();
+    } catch { /* ignore */ }
+  }
+  return new Error(`[${label}] ${detail}`);
+}
 
 interface PaymentSubmitInput {
   draftId: number;
   testerCount: TesterCount;
   rewardAmount: RewardAmount;
+  responsePeriod: number;
 }
 
 export function usePaymentSubmit() {
@@ -17,21 +30,54 @@ export function usePaymentSubmit() {
   const { openToast } = useToast();
 
   return useMutation({
-    mutationFn: async ({ draftId, testerCount, rewardAmount }: PaymentSubmitInput) => {
-      const closedAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+    mutationFn: async ({ draftId, testerCount, rewardAmount, responsePeriod }: PaymentSubmitInput) => {
+      const closedAt = new Date(Date.now() + responsePeriod * 24 * 60 * 60 * 1000)
         .toISOString()
         .slice(0, 10);
-      await updateDraft(draftId, { goalPpl: testerCount, reward: rewardAmount, closedAt });
 
-      const payRes = await createPayment({ draftId, isTestPayment: true });
-      const paymentId = payRes.data.data?.paymentId;
-      if (!paymentId) throw new Error("결제 등록 실패: paymentId를 받지 못했습니다.");
+      try {
+        const draftRes = await getDraft(draftId);
+        const status = draftRes.data.data?.status;
+        const BLOCKED: Record<string, string> = {
+          PAYMENT_CREATED: "이미 결제가 진행 중인 테스트입니다.",
+          PAYMENT_FAILED: "이전 결제가 실패했습니다. 새 테스트를 만들어 주세요.",
+          PUBLISHING: "발행 처리 중인 테스트입니다.",
+          PUBLISHED: "이미 발행된 테스트입니다.",
+          PUBLISH_FAILED: "발행에 실패한 테스트입니다. 새 테스트를 만들어 주세요.",
+          EXPIRED: "만료된 테스트입니다.",
+        };
+        if (status && status !== "DRAFT") {
+          throw new Error(BLOCKED[status] ?? `결제할 수 없는 상태입니다. (${status})`);
+        }
+      } catch (e) {
+        if (e instanceof Error && !e.message.startsWith("[")) throw e;
+        throw await stepError("초안 상태 조회 실패", e);
+      }
 
-      const execRes = await executePayment(paymentId);
-      const testId = execRes.data.data?.testId;
-      if (!testId) throw new Error("결제 실행 실패: testId를 받지 못했습니다.");
+      try {
+        await updateDraft(draftId, { goalPpl: testerCount, reward: rewardAmount, closedAt });
+      } catch (e) {
+        throw await stepError("초안 업데이트 실패", e);
+      }
 
-      return testId;
+      let paymentId: number;
+      try {
+        const payRes = await createPayment({ draftId, isTestPayment: true });
+        const id = payRes.data.data?.paymentId;
+        if (!id) throw new Error("paymentId를 받지 못했습니다.");
+        paymentId = id;
+      } catch (e) {
+        throw await stepError("결제 등록 실패", e);
+      }
+
+      try {
+        const execRes = await executePayment(paymentId);
+        const testId = execRes.data.data?.testId;
+        if (!testId) throw new Error("testId를 받지 못했습니다.");
+        return testId;
+      } catch (e) {
+        throw await stepError("결제 실행 실패", e);
+      }
     },
     onSuccess: (testId) => {
       navigate({ to: ROUTES.TEST_DETAIL, params: { testId: String(testId) } });

--- a/src/features/test-payment/model/usePaymentSubmit.ts
+++ b/src/features/test-payment/model/usePaymentSubmit.ts
@@ -1,0 +1,45 @@
+import { useMutation } from "@tanstack/react-query";
+import { useNavigate } from "@tanstack/react-router";
+import { useToast } from "@toss/tds-mobile";
+import { updateDraft } from "@/shared/api/generated/testDraft";
+import { createPayment, executePayment } from "@/shared/api/generated/payment";
+import { ROUTES } from "@/shared/constants/routes";
+import type { TesterCount, RewardAmount } from "./types";
+
+interface PaymentSubmitInput {
+  draftId: number;
+  testerCount: TesterCount;
+  rewardAmount: RewardAmount;
+}
+
+export function usePaymentSubmit() {
+  const navigate = useNavigate();
+  const { openToast } = useToast();
+
+  return useMutation({
+    mutationFn: async ({ draftId, testerCount, rewardAmount }: PaymentSubmitInput) => {
+      const closedAt = new Date(Date.now() + 30 * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10);
+      await updateDraft(draftId, { goalPpl: testerCount, reward: rewardAmount, closedAt });
+
+      const payRes = await createPayment({ draftId, isTestPayment: true });
+      const paymentId = payRes.data.data?.paymentId;
+      if (!paymentId) throw new Error("결제 등록 실패: paymentId를 받지 못했습니다.");
+
+      const execRes = await executePayment(paymentId);
+      const testId = execRes.data.data?.testId;
+      if (!testId) throw new Error("결제 실행 실패: testId를 받지 못했습니다.");
+
+      return testId;
+    },
+    onSuccess: (testId) => {
+      navigate({ to: ROUTES.TEST_DETAIL, params: { testId: String(testId) } });
+    },
+    onError: (error) => {
+      openToast(error instanceof Error ? error.message : "결제 중 오류가 발생했어요", {
+        type: "bottom",
+      });
+    },
+  });
+}

--- a/src/features/test-payment/model/usePaymentSubmit.ts
+++ b/src/features/test-payment/model/usePaymentSubmit.ts
@@ -80,7 +80,7 @@ export function usePaymentSubmit() {
       }
     },
     onSuccess: (testId) => {
-      navigate({ to: ROUTES.TEST_DETAIL, params: { testId: String(testId) } });
+      navigate({ to: ROUTES.TEST_DETAIL, params: { testId: String(testId) }, replace: true });
     },
     onError: (error) => {
       openToast(error instanceof Error ? error.message : "결제 중 오류가 발생했어요", {

--- a/src/features/test-payment/ui/PaymentFunnel.tsx
+++ b/src/features/test-payment/ui/PaymentFunnel.tsx
@@ -1,14 +1,18 @@
-import { useState } from "react";
+import { useState, useRef, useEffect } from "react";
 import { useNavigate } from "@tanstack/react-router";
+import { graniteEvent } from "@apps-in-toss/web-framework";
 import { adaptive } from "@toss/tds-colors";
-import { Border, CTAButton, FixedBottomCTA, ListRow, Text, Top } from "@toss/tds-mobile";
+import { Asset, Border, CTAButton, FixedBottomCTA, List, ListHeader, ListRow, Spacing, Text, TextField, Top } from "@toss/tds-mobile";
 import { type PaymentStep, type TesterCount, type RewardAmount } from "../model/types";
 import { calcPayment, toKRW } from "../model/calcPayment";
 import { usePaymentSubmit } from "../model/usePaymentSubmit";
 import { TesterCountStep } from "./TesterCountStep";
 import { RewardAmountStep } from "./RewardAmountStep";
+import { ResponsePeriodSheet } from "./ResponsePeriodSheet";
 import { ROUTES } from "@/shared/constants/routes";
 import { Route } from "@/routes/test/payment";
+
+const DownArrowIcon = () => <Asset.Icon frameShape={Asset.frameShape.CleanW24} backgroundColor="transparent" name="icon-arrow-down-mono" color={adaptive.grey400} aria-hidden={true} ratio="1/1" />;
 
 export function PaymentFunnel() {
   const navigate = useNavigate();
@@ -20,6 +24,40 @@ export function PaymentFunnel() {
   };
 
   const [step, setStep] = useState<PaymentStep>("main");
+  const stepRef = useRef(step);
+  useEffect(() => {
+    stepRef.current = step;
+  }, [step]);
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | null = null;
+    try {
+      unsubscribe = graniteEvent.addEventListener("backEvent", {
+        onEvent: () => {
+          if (stepRef.current === "main") {
+            handleGoBack();
+          } else {
+            setStep("main");
+          }
+        },
+        onError: (error) => {
+          console.error("backEvent error", error);
+        },
+      });
+    } catch {
+      console.warn("backEvent listener not supported in browser");
+    }
+    return () => {
+      unsubscribe?.();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const [responsePeriod, setResponsePeriod] = useState(30);
+  const [draftResponsePeriod, setDraftResponsePeriod] = useState(30);
+  const [isResponsePeriodOpen, setIsResponsePeriodOpen] = useState(false);
+  const [sheetKey, setSheetKey] = useState(0);
+
   const [testerCount, setTesterCount] = useState<TesterCount | null>(null);
   const [draftTesterCount, setDraftTesterCount] = useState<TesterCount | null>(null);
   const [rewardAmount, setRewardAmount] = useState<RewardAmount | null>(null);
@@ -53,165 +91,143 @@ export function PaymentFunnel() {
     );
   }
 
-  const payment =
-    testerCount != null && rewardAmount != null ? calcPayment(testerCount, rewardAmount) : null;
+  const payment = testerCount != null && rewardAmount != null ? calcPayment(testerCount, rewardAmount) : null;
 
   return (
-    <div className="flex flex-col h-full bg-white">
-      <Top
-        title={
-          <Top.TitleParagraph size={22} color={adaptive.grey900}>
-            결제하기
-          </Top.TitleParagraph>
-        }
-        subtitleBottom={
-          <Top.SubtitleParagraph>테스터 수와 리워드 금액을 설정해주세요</Top.SubtitleParagraph>
-        }
-      />
-      <ListRow
-        left={
-          <ListRow.AssetIcon name="icon-rank-1-mono" color="#4365cc" backgroundColor="#eef1fb" />
-        }
-        contents={
-          <ListRow.Texts type="1RowTypeA" top="테스터 수" topProps={{ color: adaptive.grey700 }} />
-        }
-        right={
-          testerCount != null ? (
-            <ListRow.Texts
-              type="Right1RowTypeA"
-              top={`${testerCount}명`}
-              topProps={{ color: adaptive.grey700 }}
-            />
-          ) : undefined
-        }
-        verticalPadding="large"
-        arrowType="right"
-        onClick={() => {
-          setDraftTesterCount(testerCount);
-          setStep("tester-count");
+    <>
+      <div className="flex flex-col h-full bg-white">
+        <Spacing size={12} />
+        <Top
+          title={
+            <Top.TitleParagraph size={22} color={adaptive.grey900}>
+              결제
+            </Top.TitleParagraph>
+          }
+        />
+        <div className="flex flex-col gap-2">
+          <TextField.Button
+            variant="line"
+            hasError={false}
+            label="테스트 응답 기간"
+            labelOption="sustain"
+            value={`${responsePeriod}일간`}
+            placeholder="테스트 응답 기간"
+            right={<DownArrowIcon />}
+            onClick={() => {
+              setDraftResponsePeriod(responsePeriod);
+              setSheetKey((k) => k + 1);
+              setIsResponsePeriodOpen(true);
+            }}
+          />
+          <TextField.Button
+            variant="line"
+            hasError={false}
+            label="테스터 수"
+            labelOption="sustain"
+            value={testerCount != null ? `${testerCount}명` : ""}
+            placeholder="선택해주세요"
+            right={<DownArrowIcon />}
+            onClick={() => {
+              setDraftTesterCount(testerCount);
+              setStep("tester-count");
+            }}
+          />
+          <TextField.Button
+            variant="line"
+            hasError={false}
+            label="리워드 금액"
+            labelOption="sustain"
+            value={rewardAmount != null ? toKRW(rewardAmount) : ""}
+            placeholder="선택해주세요"
+            right={<DownArrowIcon />}
+            onClick={() => {
+              setDraftRewardAmount(rewardAmount);
+              setStep("reward-amount");
+            }}
+          />
+        </div>
+        {payment != null && (
+          <>
+            <Border variant="height16" />
+            <List>
+              <ListHeader
+                titleWidthRatio={0.6}
+                rightAlignment="center"
+                title={
+                  <ListHeader.TitleParagraph typography="t4" fontWeight="bold" color={adaptive.grey800}>
+                    결제 금액
+                  </ListHeader.TitleParagraph>
+                }
+                right={
+                  <div className="pr-5">
+                    <Text color={adaptive.red600} typography="st8" fontWeight="bold">
+                      {toKRW(payment.total)}
+                    </Text>
+                  </div>
+                }
+              />
+              <ListRow
+                contents={
+                  <ListRow.Texts
+                    type="1RowTypeA"
+                    top="테스터 리워드"
+                    topProps={{ color: adaptive.grey700 }}
+                  />
+                }
+                right={
+                  <ListRow.Texts
+                    type="Right1RowTypeA"
+                    top={toKRW(payment.testerReward)}
+                    topProps={{ color: adaptive.grey700 }}
+                  />
+                }
+              />
+            </List>
+          </>
+        )}
+        {payment != null ? (
+          <FixedBottomCTA.Double
+            leftButton={
+              <CTAButton color="dark" variant="weak" onClick={handleGoBack}>
+                이전
+              </CTAButton>
+            }
+            rightButton={
+              <CTAButton
+                onClick={() =>
+                  submitPayment({
+                    draftId,
+                    testerCount: testerCount!,
+                    rewardAmount: rewardAmount!,
+                    responsePeriod,
+                  })
+                }
+                disabled={isPending}
+              >
+                {toKRW(payment.total)} 결제하기
+              </CTAButton>
+            }
+          />
+        ) : (
+          <FixedBottomCTA color="dark" variant="weak" onClick={handleGoBack}>
+            이전
+          </FixedBottomCTA>
+        )}
+      </div>
+      <ResponsePeriodSheet
+        open={isResponsePeriodOpen}
+        sheetKey={sheetKey}
+        draft={draftResponsePeriod}
+        onSelect={setDraftResponsePeriod}
+        onConfirm={() => {
+          setResponsePeriod(draftResponsePeriod);
+          setIsResponsePeriodOpen(false);
+        }}
+        onClose={() => {
+          setDraftResponsePeriod(responsePeriod);
+          setIsResponsePeriodOpen(false);
         }}
       />
-      {testerCount != null && (
-        <ListRow
-          left={
-            <ListRow.AssetIcon name="icon-rank-2-mono" color="#4365cc" backgroundColor="#eef1fb" />
-          }
-          contents={
-            <ListRow.Texts
-              type="1RowTypeA"
-              top="리워드 금액"
-              topProps={{ color: adaptive.grey700 }}
-            />
-          }
-          right={
-            rewardAmount != null ? (
-              <ListRow.Texts
-                type="Right1RowTypeA"
-                top={toKRW(rewardAmount)}
-                topProps={{ color: adaptive.grey700 }}
-              />
-            ) : undefined
-          }
-          verticalPadding="large"
-          arrowType="right"
-          onClick={() => {
-            setDraftRewardAmount(rewardAmount);
-            setStep("reward-amount");
-          }}
-        />
-      )}
-      {payment != null && (
-        <>
-          <Border variant="height16" />
-          <div className="flex items-center justify-between px-6 py-4">
-            <Text typography="t4" fontWeight="bold" color={adaptive.grey800}>
-              결제 금액
-            </Text>
-            <Text color={adaptive.red600} typography="st8" fontWeight="bold">
-              {toKRW(payment.total)}
-            </Text>
-          </div>
-          <ListRow
-            contents={
-              <ListRow.Texts
-                type="1RowTypeA"
-                top="테스터 리워드"
-                topProps={{ color: adaptive.grey700 }}
-              />
-            }
-            right={
-              <ListRow.Texts
-                type="Right1RowTypeA"
-                top={toKRW(payment.testerReward)}
-                topProps={{ color: adaptive.grey700 }}
-              />
-            }
-          />
-          <ListRow
-            contents={
-              <ListRow.Texts type="1RowTypeA" top="수수료" topProps={{ color: adaptive.grey700 }} />
-            }
-            right={
-              <ListRow.Texts
-                type="Right1RowTypeA"
-                top={toKRW(payment.fee)}
-                topProps={{ color: adaptive.grey700 }}
-              />
-            }
-          />
-          <ListRow
-            contents={
-              <ListRow.Texts type="1RowTypeA" top="부가세" topProps={{ color: adaptive.grey700 }} />
-            }
-            right={
-              <ListRow.Texts
-                type="Right1RowTypeA"
-                top={toKRW(payment.vat)}
-                topProps={{ color: adaptive.grey700 }}
-              />
-            }
-          />
-          <ListRow
-            contents={
-              <ListRow.Texts
-                type="1RowTypeA"
-                top="결제 합계"
-                topProps={{ color: adaptive.grey700 }}
-              />
-            }
-            right={
-              <ListRow.Texts
-                type="Right1RowTypeA"
-                top={toKRW(payment.total)}
-                topProps={{ color: adaptive.grey700 }}
-              />
-            }
-          />
-        </>
-      )}
-      {payment == null ? (
-        <FixedBottomCTA color="dark" variant="weak" onClick={handleGoBack}>
-          이전
-        </FixedBottomCTA>
-      ) : (
-        <FixedBottomCTA.Double
-          leftButton={
-            <CTAButton color="dark" variant="weak" onClick={handleGoBack}>
-              이전
-            </CTAButton>
-          }
-          rightButton={
-            <CTAButton
-              onClick={() =>
-                submitPayment({ draftId, testerCount: testerCount!, rewardAmount: rewardAmount! })
-              }
-              disabled={isPending}
-            >
-              {toKRW(payment.total)} 결제하기
-            </CTAButton>
-          }
-        />
-      )}
-    </div>
+    </>
   );
 }

--- a/src/features/test-payment/ui/PaymentFunnel.tsx
+++ b/src/features/test-payment/ui/PaymentFunnel.tsx
@@ -4,15 +4,19 @@ import { adaptive } from "@toss/tds-colors";
 import { Border, CTAButton, FixedBottomCTA, ListRow, Text, Top } from "@toss/tds-mobile";
 import { type PaymentStep, type TesterCount, type RewardAmount } from "../model/types";
 import { calcPayment, toKRW } from "../model/calcPayment";
+import { usePaymentSubmit } from "../model/usePaymentSubmit";
 import { TesterCountStep } from "./TesterCountStep";
 import { RewardAmountStep } from "./RewardAmountStep";
 import { ROUTES } from "@/shared/constants/routes";
+import { Route } from "@/routes/test/payment";
 
 export function PaymentFunnel() {
   const navigate = useNavigate();
+  const { draftId } = Route.useSearch();
+  const { mutate: submitPayment, isPending } = usePaymentSubmit();
 
   const handleGoBack = () => {
-    navigate({ to: ROUTES.TEST_CREATE, search: { payment: true } });
+    navigate({ to: ROUTES.TEST_CREATE, search: { draftId, payment: true } });
   };
 
   const [step, setStep] = useState<PaymentStep>("main");
@@ -196,7 +200,16 @@ export function PaymentFunnel() {
               이전
             </CTAButton>
           }
-          rightButton={<CTAButton onClick={() => {}}>{toKRW(payment.total)} 결제하기</CTAButton>}
+          rightButton={
+            <CTAButton
+              onClick={() =>
+                submitPayment({ draftId, testerCount: testerCount!, rewardAmount: rewardAmount! })
+              }
+              disabled={isPending}
+            >
+              {toKRW(payment.total)} 결제하기
+            </CTAButton>
+          }
         />
       )}
     </div>

--- a/src/features/test-payment/ui/ResponsePeriodSheet.tsx
+++ b/src/features/test-payment/ui/ResponsePeriodSheet.tsx
@@ -1,0 +1,41 @@
+import { BottomSheet, Wheel } from "@toss/tds-mobile";
+
+const PERIOD_OPTIONS = Array.from({ length: 28 }, (_, i) => i + 3);
+
+interface Props {
+  open: boolean;
+  sheetKey: number;
+  draft: number;
+  onSelect: (days: number) => void;
+  onConfirm: () => void;
+  onClose: () => void;
+}
+
+export function ResponsePeriodSheet({ open, sheetKey, draft, onSelect, onConfirm, onClose }: Props) {
+  const initialIndex = Math.max(0, PERIOD_OPTIONS.indexOf(draft));
+
+  return (
+    <BottomSheet
+      open={open}
+      onClose={onClose}
+      header={<BottomSheet.Header>테스트 응답 기간</BottomSheet.Header>}
+      cta={
+        <BottomSheet.CTA color="primary" variant="fill" onClick={onConfirm}>
+          선택하기
+        </BottomSheet.CTA>
+      }
+    >
+      <div style={{ height: 216 }} className="flex justify-center">
+        <Wheel
+          key={sheetKey}
+          options={PERIOD_OPTIONS}
+          initialIndex={initialIndex}
+          formatValue={(v) => `${v}일`}
+          onChange={onSelect}
+          width={160}
+          aria-label="응답 기간 선택"
+        />
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/features/test-result/ui/TestResultPage.tsx
+++ b/src/features/test-result/ui/TestResultPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
+import { graniteEvent } from "@apps-in-toss/web-framework";
 import {
   Asset,
   Button,
@@ -52,6 +53,33 @@ export function TestResultPage({ testId }: Props) {
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [isDownloadSheetOpen, setIsDownloadSheetOpen] = useState(false);
   const [selectedQuestionId, setSelectedQuestionId] = useState<number | null>(null);
+  const selectedQuestionIdRef = useRef(selectedQuestionId);
+  useEffect(() => {
+    selectedQuestionIdRef.current = selectedQuestionId;
+  }, [selectedQuestionId]);
+
+  useEffect(() => {
+    let unsubscribe: (() => void) | null = null;
+    try {
+      unsubscribe = graniteEvent.addEventListener("backEvent", {
+        onEvent: () => {
+          if (selectedQuestionIdRef.current !== null) {
+            setSelectedQuestionId(null);
+          } else {
+            window.history.back();
+          }
+        },
+        onError: (error) => {
+          console.error("backEvent error", error);
+        },
+      });
+    } catch {
+      console.warn("backEvent listener not supported in browser");
+    }
+    return () => {
+      unsubscribe?.();
+    };
+  }, []);
 
   const { data: reportData, isLoading } = useGetReportQuery(Number(testId));
   const report = reportData?.data;

--- a/src/features/test/ui/TestCreateButton.tsx
+++ b/src/features/test/ui/TestCreateButton.tsx
@@ -3,9 +3,10 @@ import { adaptive } from "@toss/tds-colors";
 
 interface Props {
   onClick: () => void;
+  disabled?: boolean;
 }
 
-export function TestCreateButton({ onClick }: Props) {
+export function TestCreateButton({ onClick, disabled }: Props) {
   return (
     <div className="flex justify-end fixed right-4 bottom-24 w-full h-fit overflow-visible">
       <IconButton
@@ -16,6 +17,7 @@ export function TestCreateButton({ onClick }: Props) {
         bgColor="#4365CC"
         aria-label="테스트 등록"
         style={{ borderRadius: "9999px" }}
+        disabled={disabled}
         onClick={onClick}
       />
     </div>

--- a/src/routes/test/create.tsx
+++ b/src/routes/test/create.tsx
@@ -1,10 +1,13 @@
-import { createFileRoute, useSearch } from '@tanstack/react-router'
+import { createFileRoute } from '@tanstack/react-router'
 import { TestCreateFunnel } from '@/features/test-create/ui/TestCreateFunnel'
 
 export const Route = createFileRoute('/test/create')({
+  validateSearch: (search: Record<string, unknown>) => ({
+    draftId: search.draftId != null ? Number(search.draftId) : undefined as number | undefined,
+    payment: search.payment === true || search.payment === 'true',
+  }),
   component: function TestCreateRoute() {
-    const search = useSearch({ strict: false }) as { payment?: boolean | string }
-    const fromPayment = search.payment === true || search.payment === 'true'
-    return <TestCreateFunnel fromPayment={fromPayment} />
+    const { draftId, payment: fromPayment } = Route.useSearch()
+    return <TestCreateFunnel draftId={draftId} fromPayment={fromPayment} />
   },
 })

--- a/src/routes/test/index.tsx
+++ b/src/routes/test/index.tsx
@@ -1,10 +1,11 @@
 import { createFileRoute, useNavigate } from "@tanstack/react-router";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation } from "@tanstack/react-query";
 import { listMyTests } from "@/shared/api/generated/test";
 import type { UserTest } from "@/features/test/model";
 import { TestBanner, TestCreateButton, TestList } from "@/features/test/ui";
 import { BottomTabBar } from "@/shared/ui/BottomTabBar";
 import { ROUTES } from "@/shared/constants/routes";
+import { createDraft } from "@/shared/api/generated/testDraft";
 
 const STATUS_MAP: Record<string, UserTest["status"]> = {
   IN_PROGRESS: "active",
@@ -19,6 +20,14 @@ export const Route = createFileRoute("/test/")({
 
 function MakerHomePage() {
   const navigate = useNavigate();
+  const { mutate: initDraft, isPending } = useMutation({
+    mutationFn: createDraft,
+    onSuccess: (res) => {
+      const draftId = res.data.data?.draftId;
+      if (!draftId) return;
+      navigate({ to: ROUTES.TEST_CREATE, search: { draftId } });
+    },
+  });
 
   const { data, isLoading } = useQuery({
     queryKey: ["listMyTests"],
@@ -43,7 +52,7 @@ function MakerHomePage() {
           navigate({ to: ROUTES.TEST_DETAIL, params: { testId: String(testId) } })
         }
       />
-      <TestCreateButton onClick={() => navigate({ to: ROUTES.TEST_CREATE })} />
+      <TestCreateButton onClick={() => initDraft()} disabled={isPending} />
 
       <BottomTabBar activeTab="test" />
     </div>

--- a/src/routes/test/index.tsx
+++ b/src/routes/test/index.tsx
@@ -25,7 +25,7 @@ function MakerHomePage() {
     onSuccess: (res) => {
       const draftId = res.data.data?.draftId;
       if (!draftId) return;
-      navigate({ to: ROUTES.TEST_CREATE, search: { draftId } });
+      navigate({ to: ROUTES.TEST_CREATE, search: { draftId, payment: false } });
     },
   });
 
@@ -52,7 +52,7 @@ function MakerHomePage() {
           navigate({ to: ROUTES.TEST_DETAIL, params: { testId: String(testId) } })
         }
       />
-      <TestCreateButton onClick={() => initDraft()} disabled={isPending} />
+      <TestCreateButton onClick={() => initDraft(undefined)} disabled={isPending} />
 
       <BottomTabBar activeTab="test" />
     </div>

--- a/src/routes/test/payment.tsx
+++ b/src/routes/test/payment.tsx
@@ -2,5 +2,8 @@ import { createFileRoute } from "@tanstack/react-router";
 import { PaymentFunnel } from "@/features/test-payment/ui/PaymentFunnel";
 
 export const Route = createFileRoute("/test/payment")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    draftId: Number(search.draftId),
+  }),
   component: PaymentFunnel,
 });


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [x] 버그 수정

## ‼️ 관련 이슈

resolves #92

## 👩🏻‍💻 작업 사항

**테스트 등록 + 결제 플로우 구현**
- 테스트 등록 퍼널 (기본 정보 → 서비스 설명 → 이미지 → 질문 등록) 구현
- 결제 페이지 구현 (테스터 수, 리워드 금액, 응답 기간 선택)
- 결제 성공 시 테스트 상세 페이지로 이동

**버그 수정**
- 트리 테스트 노드 데이터 구조 오류 수정: 3단계 이하 노드가 `{id, name, children}` 형태로 전송되던 문제 → 재귀 변환으로 모든 깊이에서 `{label, children}` 형태로 전송
- 결제 완료 후 뒤로가기 시 테스트 등록 퍼널으로 돌아가는 문제 수정: create→payment 이동 시 `replace: true` 추가
- 질문 미리보기 오버레이에서 하드웨어 뒤로가기 시 페이지 이탈 문제 수정: `backEvent` 리스너 추가해 오버레이 열려있을 때 뒤로가기 누르면 오버레이 닫히도록 처리

## 📢 기타(공유 사항)
없음