### PR TITLE
[FEAT] 인트로 및 테스트 상세 ui 수정

### DIFF
--- a/granite.config.ts
+++ b/granite.config.ts
@@ -3,9 +3,9 @@ import { defineConfig } from "@apps-in-toss/web-framework/config";
 export default defineConfig({
   appName: "mate",
   brand: {
-    displayName: "mate", // 화면에 노출될 앱의 한글 이름으로 바꿔주세요.
-    primaryColor: "#4265CC", // 화면에 노출될 앱의 기본 색상으로 바꿔주세요.
-    icon: "/vite.svg", // 화면에 노출될 앱의 아이콘 이미지 주소로 바꿔주세요.
+    displayName: "메이트",
+    primaryColor: "#4265CC",
+    icon: "https://static.toss.im/appsintoss/33213/ac1b1d5e-c6d7-4943-9236-fcbd2bc825c0.png",
   },
   web: {
     host: "localhost",

--- a/src/features/discovery-detail/ui/TestDetailInfo.tsx
+++ b/src/features/discovery-detail/ui/TestDetailInfo.tsx
@@ -1,11 +1,4 @@
-import {
-  Border,
-  ListHeader,
-  ListRow,
-  Paragraph,
-  Spacing,
-  Text,
-} from "@toss/tds-mobile";
+import { ListHeader, ListRow, Paragraph, Text } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 
 interface Props {
@@ -15,12 +8,7 @@ interface Props {
   serviceDescription: string;
 }
 
-export function TestDetailInfo({
-  reward,
-  description,
-  serviceName,
-  serviceDescription,
-}: Props) {
+export function TestDetailInfo({ reward, description, serviceName, serviceDescription }: Props) {
   return (
     <>
       <ListRow
@@ -36,9 +24,7 @@ export function TestDetailInfo({
             type="2RowTypeF"
             top="보상 머니"
             topProps={{ color: adaptive.grey500 }}
-            bottom={
-              <Paragraph.Text>{reward.toLocaleString()}원</Paragraph.Text>
-            }
+            bottom={<Paragraph.Text>{reward.toLocaleString()}원</Paragraph.Text>}
             bottomProps={{ color: adaptive.grey800, fontWeight: "bold" }}
           />
         }
@@ -67,10 +53,6 @@ export function TestDetailInfo({
         horizontalPadding="small"
       />
 
-      <Spacing size={16} />
-      <Border variant="height16" />
-      <Spacing size={16} />
-
       <ListRow
         left={
           <ListRow.AssetIcon
@@ -93,29 +75,14 @@ export function TestDetailInfo({
 
       <ListHeader
         title={
-          <ListHeader.TitleParagraph
-            color={adaptive.grey800}
-            fontWeight="bold"
-            typography="t5"
-          >
+          <ListHeader.TitleParagraph color={adaptive.grey800} fontWeight="bold" typography="t5">
             {serviceName}
           </ListHeader.TitleParagraph>
         }
-        description={
-          <ListHeader.DescriptionParagraph>
-            서비스명
-          </ListHeader.DescriptionParagraph>
-        }
-        descriptionPosition="top"
+        descriptionPosition="bottom"
       />
-
-      <div className="px-6 pb-4">
-        <Text
-          display="block"
-          color={adaptive.grey700}
-          typography="t5"
-          fontWeight="regular"
-        >
+      <div className="w-full flex flex-row justify-start items-center px-6 pb-4">
+        <Text display="block" color={adaptive.grey700} typography="t5" fontWeight="regular">
           {serviceDescription}
         </Text>
       </div>

--- a/src/features/intro/ui/ServiceIntroPage.tsx
+++ b/src/features/intro/ui/ServiceIntroPage.tsx
@@ -1,17 +1,11 @@
 import { useMutation } from "@tanstack/react-query";
-import { Asset, FixedBottomCTA, Spacing, Stepper, StepperRow, Top } from "@toss/tds-mobile";
+import { FixedBottomCTA, List, ListRow, Top } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { useNavigate } from "@tanstack/react-router";
 import { appLogin } from "@apps-in-toss/web-framework";
 import { loginWithToss } from "@/shared/api/generated/auth";
 import { setToken, setRefreshToken } from "@/shared/api/client";
 import { ROUTES } from "@/shared/constants/routes";
-
-const STEPS = [
-  { icon: "icon-phone-vibration", title: "새로운 서비스를 구경해요" },
-  { icon: "icon-pencil-blue", title: "간단한 테스트를 진행해요" },
-  { icon: "icon-coin-stack-blue", title: "테스트 참여하고 리워드 받아요" },
-];
 
 export function ServiceIntroPage() {
   const navigate = useNavigate();
@@ -37,31 +31,59 @@ export function ServiceIntroPage() {
   return (
     <div className="flex flex-col min-h-dvh bg-white">
       <Top
-        lowerGap={0}
         title={
           <Top.TitleParagraph size={22} color={adaptive.grey900}>
-            메이커와 테스터를 이어주는 테스트 리워드 서비스
+            테스트 리워드 플랫폼
           </Top.TitleParagraph>
         }
-        subtitleBottom={<Top.SubtitleParagraph>리워드를 받아요</Top.SubtitleParagraph>}
+        subtitleTop={
+          <Top.SubtitleParagraph>서비스 메이커와 테스터를 이어주는</Top.SubtitleParagraph>
+        }
       />
       <img src="/images/intro.png" alt="" aria-hidden={true} className="w-full" />
-      <Spacing size={40} />
-      <Stepper>
-        {STEPS.map((step, i) => (
-          <StepperRow
-            key={step.title}
-            left={
-              <StepperRow.AssetFrame
-                shape={Asset.frameShape.CleanW32}
-                content={<Asset.ContentIcon name={step.icon} aria-hidden={true} />}
-              />
-            }
-            center={<StepperRow.Texts type="A" title={step.title} />}
-            hideLine={i === STEPS.length - 1}
-          />
-        ))}
-      </Stepper>
+      <List>
+        <ListRow
+          left={
+            <ListRow.Icon
+              shape="no-background"
+              url="https://static.toss.im/2d-emojis/png/4x/u1F50E.png"
+            />
+          }
+          contents={
+            <ListRow.Texts
+              type="1RowTypeC"
+              top="새로운 서비스 구경하기"
+              topProps={{ color: adaptive.grey800 }}
+            />
+          }
+        />
+        <ListRow
+          left={<ListRow.Icon shape="no-background" name="icon-pencil-blue" />}
+          contents={
+            <ListRow.Texts
+              type="1RowTypeC"
+              top="간단한 테스트 진행하기"
+              topProps={{ color: adaptive.grey800 }}
+            />
+          }
+        />
+        <ListRow
+          left={
+            <ListRow.Icon
+              shape="no-background"
+              url="https://static.toss.im/2d-emojis/png/4x/u1F4B0.png"
+            />
+          }
+          contents={
+            <ListRow.Texts
+              type="1RowTypeC"
+              top="참여 완료하고 리워드 받기"
+              topProps={{ color: adaptive.grey800 }}
+            />
+          }
+          verticalPadding="large"
+        />
+      </List>
       <FixedBottomCTA onClick={() => loginMutation.mutate()} disabled={loginMutation.isPending}>
         {loginMutation.isPending ? "로그인 중" : "시작하기"}
       </FixedBottomCTA>


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [x] 새로운 기능 추가
-   [ ] 버그 수정
-   [x] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

<!-- 이슈 키워드와 함께 #을 입력한 후 이슈 번호를 선택해주세요. -->
<!-- 에시 : resolves #1 -->

resolves #102 

## 👩🏻‍💻 작업 사항
<!-- 주요 작업 내용을 간단히 작성해주세요.(스크린샷도 있으면 좋아요!) -->
인트로 페이지 UI 수정 (ServiceIntroPage.tsx)
- 하단 단계 안내를 Stepper → List + ListRow 형태로 교체
- 이모지 아이콘 및 텍스트 스타일 적용

테스트 상세화면 UI 수정 (TestDetailInfo.tsx)
- "서비스 소개" 섹션에서 "서비스명" 라벨 제거
- ListHeader + 서비스 설명 텍스트 구조로 정리

헤더 로고 이미지 추가 (granite.config.ts)
- brand.icon을 콘솔 업로드 URL로 변경
- 토스 앱 내비게이션 바 좌측에 MATE 로고 표시

## 📢 기타(공유 사항) 
<!-- 공유할 내용, 추가 논의가 필요한 사항, 배포 시 유의사항 등을 작성해주세요. -->
- 네비게이션 바 로고는 토스 앱에서만 표시되며 로컬 개발 환경에서는 확인 불가