### PR TITLE
[CHORE] 테스트 등록 API 임시 비활성화

### DIFF
--- a/src/features/test-participate/ui/ParticipatePage.tsx
+++ b/src/features/test-participate/ui/ParticipatePage.tsx
@@ -1,15 +1,15 @@
 import { useState } from "react";
 import { useNavigate } from "@tanstack/react-router";
-import { useQueryClient } from "@tanstack/react-query";
+// import { useQueryClient } from "@tanstack/react-query";
 import { Asset, CTAButton, FixedBottomCTA, ProgressBar, Spacing, Text } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { useParticipateFunnel } from "../model";
 import { ROUTES } from "@/shared/constants/routes";
 import { QuestionRenderer } from "./QuestionRenderer";
 import { useParticipateTestQuery } from "../api/useParticipateTestQuery";
-import { useSubmitAnswersMutation } from "../api/useSubmitAnswersMutation";
-import { mapAnswersToApiRequest } from "../api/mappers";
-import { getListTestsUrl } from "@/shared/api/generated/test";
+// import { useSubmitAnswersMutation } from "../api/useSubmitAnswersMutation";
+// import { mapAnswersToApiRequest } from "../api/mappers";
+// import { getListTestsUrl } from "@/shared/api/generated/test";
 import type { ParticipateTest } from "../model/types";
 
 interface Props {
@@ -55,23 +55,24 @@ interface FunnelProps {
   testId: number;
 }
 
-function ParticipateFunnelContent({ test, testId }: FunnelProps) {
+function ParticipateFunnelContent({ test }: FunnelProps) {
   const navigate = useNavigate();
-  const queryClient = useQueryClient();
-  const { mutate: submitAnswers } = useSubmitAnswersMutation();
+  // const queryClient = useQueryClient();
+  // const { mutate: submitAnswers } = useSubmitAnswersMutation();
   const [submitted, setSubmitted] = useState(false);
 
-  const funnel = useParticipateFunnel(test.questions, (answers) => {
-    const body = mapAnswersToApiRequest(test.questions, answers);
-    submitAnswers(
-      { testId, body },
-      {
-        onSuccess: () => {
-          queryClient.invalidateQueries({ queryKey: [getListTestsUrl()] });
-          setSubmitted(true);
-        },
-      },
-    );
+  const funnel = useParticipateFunnel(test.questions, () => {
+    // const body = mapAnswersToApiRequest(test.questions, answers);
+    // submitAnswers(
+    //   { testId, body },
+    //   {
+    //     onSuccess: () => {
+    //       queryClient.invalidateQueries({ queryKey: [getListTestsUrl()] });
+    //       setSubmitted(true);
+    //     },
+    //   },
+    // );
+    setSubmitted(true);
   });
 
   if (submitted) {


### PR DESCRIPTION
## Summary

- `ParticipatePage`에서 답안 제출 API 호출 코드를 임시 주석 처리
- 현재 백엔드 API 미연동 상태에서 퍼널 흐름 테스트를 위해 제출 로직 비활성화
- 제출 완료 시 `setSubmitted(true)` 직접 호출로 완료 화면 진입 가능하도록 처리

## Changes

- `useSubmitAnswersMutation`, `mapAnswersToApiRequest`, `getListTestsUrl` import 주석 처리
- `useQueryClient` import 주석 처리
- `submitAnswers` 뮤테이션 호출 및 `queryClient.invalidateQueries` 주석 처리
- `ParticipateFunnelContent`의 `testId` prop 임시 제거

## Test plan

- [ ] 테스트 참여 퍼널이 정상적으로 진행되는지 확인
- [ ] 마지막 질문 완료 후 완료 화면으로 이동하는지 확인

> API 연동 완료 후 주석 해제 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)