### PR TITLE
[FIX] 테스트 생성/참여 UX 개선 및 버그 수정

### DIFF
--- a/src/features/discovery-detail/ui/TestDetailInfo.tsx
+++ b/src/features/discovery-detail/ui/TestDetailInfo.tsx
@@ -1,4 +1,4 @@
-import { ListHeader, ListRow, Paragraph, Text } from "@toss/tds-mobile";
+import { ListHeader, ListRow, Text } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 
 interface Props {
@@ -24,7 +24,7 @@ export function TestDetailInfo({ reward, description, serviceName, serviceDescri
             type="2RowTypeF"
             top="보상 머니"
             topProps={{ color: adaptive.grey500 }}
-            bottom={<Paragraph.Text>{reward.toLocaleString()}원</Paragraph.Text>}
+            bottom={`${reward.toLocaleString()}원`}
             bottomProps={{ color: adaptive.grey800, fontWeight: "bold" }}
           />
         }
@@ -46,7 +46,7 @@ export function TestDetailInfo({ reward, description, serviceName, serviceDescri
             top="테스트 한줄 소개"
             topProps={{ color: adaptive.grey500 }}
             bottom={description}
-            bottomProps={{ color: adaptive.grey700, fontWeight: "medium" }}
+            bottomProps={{ color: adaptive.grey700, fontWeight: "semibold" }}
           />
         }
         verticalPadding="small"
@@ -63,14 +63,14 @@ export function TestDetailInfo({ reward, description, serviceName, serviceDescri
         }
         contents={
           <ListRow.Texts
-            type="2RowTypeC"
+            type="2RowTypeF"
             top="서비스 소개"
-            topProps={{ color: adaptive.grey800, fontWeight: "bold" }}
+            topProps={{ color: adaptive.grey500 }}
             bottom="진행될 테스트의 서비스를 소개할게요"
-            bottomProps={{ color: adaptive.grey500 }}
+            bottomProps={{ color: adaptive.grey800, fontWeight: "semibold" }}
           />
         }
-        verticalPadding="small"
+        horizontalPadding="small"
       />
 
       <ListHeader

--- a/src/features/question-ab/create/AbCreatePage.tsx
+++ b/src/features/question-ab/create/AbCreatePage.tsx
@@ -1,6 +1,11 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { openCamera, fetchAlbumPhotos, OpenCameraPermissionError, FetchAlbumPhotosPermissionError } from "@apps-in-toss/web-framework";
+import {
+  openCamera,
+  fetchAlbumPhotos,
+  OpenCameraPermissionError,
+  FetchAlbumPhotosPermissionError,
+} from "@apps-in-toss/web-framework";
 import { FixedBottomCTA, ListRow } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { useTestCreateForm } from "@/features/test-create/model/useTestCreateForm";
@@ -32,7 +37,10 @@ export function AbCreatePage({ questionId, onClose }: AbCreatePageProps) {
   const [imageUrlB, setImageUrlB] = useState(existingAb?.imageUrlB ?? "");
   const [activeSlot, setActiveSlot] = useState<"a" | "b" | null>(null);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "AB_TEST"; selected: "A" | "B" | null }>({ type: "AB_TEST", selected: null });
+  const [previewAnswer, setPreviewAnswer] = useState<{
+    type: "AB_TEST";
+    selected: "A" | "B" | null;
+  }>({ type: "AB_TEST", selected: null });
   const [ratio, setRatio] = useState<AbRatio>(existingAb?.ratio ?? "9:16");
   const [isRatioSheetOpen, setIsRatioSheetOpen] = useState(false);
 
@@ -98,7 +106,7 @@ export function AbCreatePage({ questionId, onClose }: AbCreatePageProps) {
       {isQuestionInputCompleted && (
         <>
           <TesterPreviewListRow onClick={() => setIsPreviewOpen(true)} />
-          
+
           <ListRow
             as="button"
             className="w-full text-left"
@@ -185,7 +193,7 @@ export function AbCreatePage({ questionId, onClose }: AbCreatePageProps) {
             answer={previewAnswer}
             onChange={setPreviewAnswer}
           />
-          <FixedBottomCTA onClick={() => setIsPreviewOpen(false)}>
+          <FixedBottomCTA color="dark" variant="weak" onClick={() => setIsPreviewOpen(false)}>
             돌아가기
           </FixedBottomCTA>
         </motion.div>

--- a/src/features/question-cardsort/create/CardSortCreatePage.tsx
+++ b/src/features/question-cardsort/create/CardSortCreatePage.tsx
@@ -25,15 +25,22 @@ export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePagePr
   const existingCardSort = existing?.typeId === "CARD_SORTING" ? existing : null;
 
   const [questionTitle, setQuestionTitle] = useState(existingCardSort?.title ?? "");
-  const [questionDescription, setQuestionDescription] = useState(existingCardSort?.description ?? "");
+  const [questionDescription, setQuestionDescription] = useState(
+    existingCardSort?.description ?? "",
+  );
   const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState(
     (existingCardSort?.title ?? "").trim().length > 0,
   );
-  const [categories, setCategories] = useState<CardSortCategory[]>(existingCardSort?.categories ?? []);
+  const [categories, setCategories] = useState<CardSortCategory[]>(
+    existingCardSort?.categories ?? [],
+  );
   const [cards, setCards] = useState<CardSortCard[]>(existingCardSort?.cards ?? []);
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "CARD_SORTING"; placements: Record<string, string> }>({ type: "CARD_SORTING", placements: {} });
+  const [previewAnswer, setPreviewAnswer] = useState<{
+    type: "CARD_SORTING";
+    placements: Record<string, string>;
+  }>({ type: "CARD_SORTING", placements: {} });
 
   const [editingCategoryId, setEditingCategoryId] = useState<string | null>(null);
   const [isCategorySheetOpen, setIsCategorySheetOpen] = useState(false);
@@ -58,9 +65,7 @@ export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePagePr
 
   const handleConfirmCategory = (label: string) => {
     if (editingCategoryId) {
-      setCategories((prev) =>
-        prev.map((c) => (c.id === editingCategoryId ? { ...c, label } : c)),
-      );
+      setCategories((prev) => prev.map((c) => (c.id === editingCategoryId ? { ...c, label } : c)));
     } else {
       setCategories((prev) => [...prev, { id: generateId(), label }]);
     }
@@ -80,9 +85,7 @@ export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePagePr
 
   const handleConfirmCard = (label: string) => {
     if (editingCardId) {
-      setCards((prev) =>
-        prev.map((c) => (c.id === editingCardId ? { ...c, label } : c)),
-      );
+      setCards((prev) => prev.map((c) => (c.id === editingCardId ? { ...c, label } : c)));
     } else {
       setCards((prev) => [...prev, { id: generateId(), label }]);
     }
@@ -186,7 +189,7 @@ export function CardSortCreatePage({ questionId, onClose }: CardSortCreatePagePr
             answer={previewAnswer}
             onChange={setPreviewAnswer}
           />
-          <FixedBottomCTA onClick={() => setIsPreviewOpen(false)}>
+          <FixedBottomCTA color="dark" variant="weak" onClick={() => setIsPreviewOpen(false)}>
             돌아가기
           </FixedBottomCTA>
         </motion.div>

--- a/src/features/question-fivesec/answer/FivesecAnswerPage.tsx
+++ b/src/features/question-fivesec/answer/FivesecAnswerPage.tsx
@@ -77,7 +77,14 @@ export function FivesecAnswerPage({ question, answer, onChange, onPrev, onGoNext
   }
 
   if (phase === "preview") {
-    return <FivesecPreviewPhase ratio={ratio ?? "9:16"} onStart={startCountdown} />;
+    return (
+      <FivesecPreviewPhase
+        ratio={ratio ?? "9:16"}
+        onStart={startCountdown}
+        onPrev={isPreview ? onPrev : undefined}
+        prevLabel={prevLabel}
+      />
+    );
   }
 
   if (phase === "countdown") {

--- a/src/features/question-fivesec/answer/FivesecAnswerPage.tsx
+++ b/src/features/question-fivesec/answer/FivesecAnswerPage.tsx
@@ -88,7 +88,14 @@ export function FivesecAnswerPage({ question, answer, onChange, onPrev, onGoNext
   }
 
   if (phase === "countdown") {
-    return <FivesecCountdownPhase imageUrl={imageUrl} ratio={ratio ?? "9:16"} />;
+    return (
+      <FivesecCountdownPhase
+        imageUrl={imageUrl}
+        ratio={ratio ?? "9:16"}
+        onPrev={isPreview ? onPrev : undefined}
+        prevLabel={prevLabel}
+      />
+    );
   }
 
   if (isSubjective) {
@@ -121,6 +128,7 @@ export function FivesecAnswerPage({ question, answer, onChange, onPrev, onGoNext
       isFirst={isFirst}
       isLast={isLast}
       prevLabel={prevLabel}
+      onlyPrev={isPreview}
       otherText={answer?.text ?? ""}
       onSelect={handleSelect}
       onOtherTextChange={(text) => onChange({ type: "FIVE_SECOND", selectedIds: otherChoice ? [otherChoice.id] : [], text })}

--- a/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecCountdownPhase.tsx
@@ -1,13 +1,16 @@
 import { motion } from "framer-motion";
+import { FixedBottomCTA } from "@toss/tds-mobile";
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
 import { RATIO_TO_CSS, type AbRatio } from "@/shared/constants/imageRatio";
 
 interface Props {
   imageUrl: string;
   ratio: AbRatio;
+  onPrev?: () => void;
+  prevLabel?: string;
 }
 
-export function FivesecCountdownPhase({ imageUrl, ratio }: Props) {
+export function FivesecCountdownPhase({ imageUrl, ratio, onPrev, prevLabel = "돌아가기" }: Props) {
   return (
     <motion.div
       className="flex flex-col flex-1 bg-white"
@@ -32,7 +35,13 @@ export function FivesecCountdownPhase({ imageUrl, ratio }: Props) {
           <img src={imageUrl} alt="5초 테스트 이미지" className="h-full w-full object-cover" />
         </div>
       </div>
-      <div className="h-18 shrink-0" aria-hidden={true} />
+      {onPrev ? (
+        <FixedBottomCTA color="dark" variant="weak" onClick={onPrev}>
+          {prevLabel}
+        </FixedBottomCTA>
+      ) : (
+        <div className="h-18 shrink-0" aria-hidden={true} />
+      )}
     </motion.div>
   );
 }

--- a/src/features/question-fivesec/answer/FivesecMultipleAnswerPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecMultipleAnswerPhase.tsx
@@ -14,6 +14,7 @@ interface Props {
   isFirst: boolean;
   isLast: boolean;
   prevLabel?: string;
+  onlyPrev?: boolean;
   otherText?: string;
   onSelect: (id: string) => void;
   onOtherTextChange?: (text: string) => void;
@@ -31,6 +32,7 @@ export function FivesecMultipleAnswerPhase({
   isFirst,
   isLast,
   prevLabel = "이전",
+  onlyPrev,
   otherText = "",
   onSelect,
   onOtherTextChange,
@@ -142,7 +144,9 @@ export function FivesecMultipleAnswerPhase({
           </>
         )}
       </div>
-      {isOtherFieldFocused ? (
+      {onlyPrev ? (
+        <FixedBottomCTA color="dark" variant="weak" onClick={onPrev}>{prevLabel}</FixedBottomCTA>
+      ) : isOtherFieldFocused ? (
         <FixedBottomCTA onClick={handleConfirm}>확인</FixedBottomCTA>
       ) : isFirst ? (
         <FixedBottomCTA disabled={!canGoNext} onClick={onGoNext}>

--- a/src/features/question-fivesec/answer/FivesecPreviewPhase.tsx
+++ b/src/features/question-fivesec/answer/FivesecPreviewPhase.tsx
@@ -1,15 +1,17 @@
 import { motion } from "framer-motion";
 import { adaptive } from "@toss/tds-colors";
-import { Text } from "@toss/tds-mobile";
+import { FixedBottomCTA, Text } from "@toss/tds-mobile";
 import { QuestionHeader } from "@/features/test-participate/ui/QuestionHeader";
 import { RATIO_TO_CSS, type AbRatio } from "@/shared/constants/imageRatio";
 
 interface Props {
   ratio: AbRatio;
   onStart: () => void;
+  onPrev?: () => void;
+  prevLabel?: string;
 }
 
-export function FivesecPreviewPhase({ ratio, onStart }: Props) {
+export function FivesecPreviewPhase({ ratio, onStart, onPrev, prevLabel = "돌아가기" }: Props) {
   return (
     <div className="flex flex-col flex-1 bg-white">
       <QuestionHeader categoryLabel="5초 테스트" title={`5초간\n아래 사진에 집중해주세요`} />
@@ -38,7 +40,13 @@ export function FivesecPreviewPhase({ ratio, onStart }: Props) {
           </Text>
         </motion.div>
       </div>
-      <div className="h-18 shrink-0" aria-hidden={true} />
+      {onPrev ? (
+        <FixedBottomCTA color="dark" variant="weak" onClick={onPrev}>
+          {prevLabel}
+        </FixedBottomCTA>
+      ) : (
+        <div className="h-18 shrink-0" aria-hidden={true} />
+      )}
     </div>
   );
 }

--- a/src/features/question-multiple/create/MultipleCreatePage.tsx
+++ b/src/features/question-multiple/create/MultipleCreatePage.tsx
@@ -15,10 +15,7 @@ interface MultipleCreatePageProps {
   onClose: () => void;
 }
 
-export function MultipleCreatePage({
-  questionId,
-  onClose,
-}: MultipleCreatePageProps) {
+export function MultipleCreatePage({ questionId, onClose }: MultipleCreatePageProps) {
   const { updateQuestion, questions } = useTestCreateForm();
   const existing = questions.find((q) => q.id === questionId)?.data;
   const existingMultiple = existing?.typeId === "OBJECTIVE" ? existing : null;
@@ -29,9 +26,7 @@ export function MultipleCreatePage({
   const [isMultiSelectEnabled, setIsMultiSelectEnabled] = useState(
     existingMultiple?.isMultiSelectEnabled ?? false,
   );
-  const [questionTitle, setQuestionTitle] = useState(
-    existingMultiple?.title ?? "",
-  );
+  const [questionTitle, setQuestionTitle] = useState(existingMultiple?.title ?? "");
   const [questionDescription, setQuestionDescription] = useState(
     existingMultiple?.description ?? "",
   );
@@ -39,18 +34,15 @@ export function MultipleCreatePage({
     (existingMultiple?.title ?? "").trim().length > 0,
   );
   const [isChoiceEditorOpen, setIsChoiceEditorOpen] = useState(false);
-  const [choices, setChoices] = useState<MultipleChoiceItem[]>(
-    existingMultiple?.choices ?? [],
-  );
-  const [minSelectCount, setMinSelectCount] = useState(
-    existingMultiple?.minSelectCount ?? 1,
-  );
-  const [maxSelectCount, setMaxSelectCount] = useState(
-    existingMultiple?.maxSelectCount ?? 2,
-  );
+  const [choices, setChoices] = useState<MultipleChoiceItem[]>(existingMultiple?.choices ?? []);
+  const [minSelectCount, setMinSelectCount] = useState(existingMultiple?.minSelectCount ?? 1);
+  const [maxSelectCount, setMaxSelectCount] = useState(existingMultiple?.maxSelectCount ?? 2);
   const [editingChoiceId, setEditingChoiceId] = useState<string | null>(null);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "OBJECTIVE"; selectedIds: string[] }>({ type: "OBJECTIVE", selectedIds: [] });
+  const [previewAnswer, setPreviewAnswer] = useState<{ type: "OBJECTIVE"; selectedIds: string[] }>({
+    type: "OBJECTIVE",
+    selectedIds: [],
+  });
 
   const editingChoice = choices.find((choice) => choice.id === editingChoiceId) ?? null;
   const isCompleteDisabled = questionTitle.trim().length === 0 || choices.length < 2;
@@ -97,9 +89,7 @@ export function MultipleCreatePage({
               setIsMultiSelectEnabled(checked);
               if (!checked) {
                 setMinSelectCount(1);
-                setMaxSelectCount(
-                  Math.max(Math.min(2, Math.max(choices.length, 1)), 1),
-                );
+                setMaxSelectCount(Math.max(Math.min(2, Math.max(choices.length, 1)), 1));
               }
             }}
             onChangeMinSelectCount={(value) => {
@@ -153,9 +143,7 @@ export function MultipleCreatePage({
               if (editingChoice) {
                 setChoices((prev) =>
                   prev.map((c) =>
-                    c.id === editingChoice.id
-                      ? { ...c, name: choiceName, imageUrl }
-                      : c,
+                    c.id === editingChoice.id ? { ...c, name: choiceName, imageUrl } : c,
                   ),
                 );
               } else {
@@ -206,7 +194,7 @@ export function MultipleCreatePage({
             answer={previewAnswer}
             onChange={setPreviewAnswer}
           />
-          <FixedBottomCTA onClick={() => setIsPreviewOpen(false)}>
+          <FixedBottomCTA color="dark" variant="weak" onClick={() => setIsPreviewOpen(false)}>
             돌아가기
           </FixedBottomCTA>
         </motion.div>

--- a/src/features/question-scale/create/ScaleCreatePage.tsx
+++ b/src/features/question-scale/create/ScaleCreatePage.tsx
@@ -25,7 +25,9 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
   const [questionTitle, setQuestionTitle] = useState(existingScale?.title ?? "");
   const [questionDescription, setQuestionDescription] = useState(existingScale?.description ?? "");
   const [questionImageUrl, setQuestionImageUrl] = useState(existingScale?.imageUrl ?? "");
-  const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState((existingScale?.title ?? "").trim().length > 0);
+  const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState(
+    (existingScale?.title ?? "").trim().length > 0,
+  );
   const [scaleCount, setScaleCount] = useState<5 | 7>(existingScale?.scaleCount ?? 5);
   const [minLabel, setMinLabel] = useState(existingScale?.minLabel ?? "전혀 아니다");
   const [maxLabel, setMaxLabel] = useState(existingScale?.maxLabel ?? "매우 그렇다");
@@ -33,7 +35,10 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
   const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "SCALE"; value: number | null }>({ type: "SCALE", value: null });
+  const [previewAnswer, setPreviewAnswer] = useState<{ type: "SCALE"; value: number | null }>({
+    type: "SCALE",
+    value: null,
+  });
 
   const { isPhotoSheetOpen, openPhotoSheet, closePhotoSheet, handleCamera, handleAlbum } =
     useQuestionImageUpload(setQuestionImageUrl);
@@ -103,8 +108,18 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
                   }}
                 >
                   <div className="flex h-full w-full flex-col items-end justify-between">
-                    <button type="button" onClick={() => setQuestionImageUrl("")} aria-label="이미지 삭제">
-                      <Asset.Icon frameShape={Asset.frameShape.CircleXSmall} backgroundColor={adaptive.greyOpacity600} name="icon-sweetshop-x-white" scale={0.66} aria-hidden />
+                    <button
+                      type="button"
+                      onClick={() => setQuestionImageUrl("")}
+                      aria-label="이미지 삭제"
+                    >
+                      <Asset.Icon
+                        frameShape={Asset.frameShape.CircleXSmall}
+                        backgroundColor={adaptive.greyOpacity600}
+                        name="icon-sweetshop-x-white"
+                        scale={0.66}
+                        aria-hidden
+                      />
                     </button>
                   </div>
                 </div>
@@ -179,7 +194,7 @@ export function ScaleCreatePage({ questionId, onClose }: ScaleCreatePageProps) {
             answer={previewAnswer}
             onChange={setPreviewAnswer}
           />
-          <FixedBottomCTA onClick={() => setIsPreviewOpen(false)}>
+          <FixedBottomCTA color="dark" variant="weak" onClick={() => setIsPreviewOpen(false)}>
             돌아가기
           </FixedBottomCTA>
         </motion.div>

--- a/src/features/question-subjective/create/SubjectiveCreatePage.tsx
+++ b/src/features/question-subjective/create/SubjectiveCreatePage.tsx
@@ -21,21 +21,13 @@ export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePa
   const existing = questions.find((q) => q.id === questionId)?.data;
   const existingSubjective = existing?.typeId === "SUBJECTIVE" ? existing : null;
 
-  const [questionTitle, setQuestionTitle] = useState(
-    existingSubjective?.title ?? "",
-  );
+  const [questionTitle, setQuestionTitle] = useState(existingSubjective?.title ?? "");
   const [questionDescription, setQuestionDescription] = useState(
     existingSubjective?.description ?? "",
   );
-  const [questionImageUrl, setQuestionImageUrl] = useState(
-    existingSubjective?.imageUrl ?? "",
-  );
-  const [placeholder] = useState(
-    existingSubjective?.placeholder ?? "",
-  );
-  const [maxLength] = useState<number | null>(
-    existingSubjective?.maxLength ?? null,
-  );
+  const [questionImageUrl, setQuestionImageUrl] = useState(existingSubjective?.imageUrl ?? "");
+  const [placeholder] = useState(existingSubjective?.placeholder ?? "");
+  const [maxLength] = useState<number | null>(existingSubjective?.maxLength ?? null);
   const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState(
     (existingSubjective?.title ?? "").trim().length > 0,
   );
@@ -44,7 +36,10 @@ export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePa
 
   const isCompleteDisabled = questionTitle.trim().length === 0;
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "SUBJECTIVE"; text: string }>({ type: "SUBJECTIVE", text: "" });
+  const [previewAnswer, setPreviewAnswer] = useState<{ type: "SUBJECTIVE"; text: string }>({
+    type: "SUBJECTIVE",
+    text: "",
+  });
 
   return (
     <motion.div
@@ -161,7 +156,7 @@ export function SubjectiveCreatePage({ questionId, onClose }: SubjectiveCreatePa
             answer={previewAnswer}
             onChange={setPreviewAnswer}
           />
-          <FixedBottomCTA onClick={() => setIsPreviewOpen(false)}>
+          <FixedBottomCTA color="dark" variant="weak" onClick={() => setIsPreviewOpen(false)}>
             돌아가기
           </FixedBottomCTA>
         </motion.div>

--- a/src/features/question-tree/create/TreeCreatePage.tsx
+++ b/src/features/question-tree/create/TreeCreatePage.tsx
@@ -10,7 +10,6 @@ import { useTestCreateForm } from "@/features/test-create/model/useTestCreateFor
 import { QuestionCreateTopSection } from "@/features/test-create/ui/QuestionCreateTopSection";
 import { TesterPreviewListRow } from "@/features/test-create/ui/TesterPreviewListRow";
 
-
 interface TreeCreatePageProps {
   questionId: string;
   onClose: () => void;
@@ -25,33 +24,27 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
   const existing = questions.find((q) => q.id === questionId)?.data;
   const existingTree = existing?.typeId === "TREE_TEST" ? existing : null;
 
-  const [questionTitle, setQuestionTitle] = useState(
-    existingTree?.title ?? "",
-  );
-  const [questionDescription, setQuestionDescription] = useState(
-    existingTree?.description ?? "",
-  );
+  const [questionTitle, setQuestionTitle] = useState(existingTree?.title ?? "");
+  const [questionDescription, setQuestionDescription] = useState(existingTree?.description ?? "");
   const [isQuestionInputCompleted, setIsQuestionInputCompleted] = useState(
     (existingTree?.title ?? "").trim().length > 0,
   );
-  const [nodes, setNodes] = useState<TreeNodeItem[]>(
-    existingTree?.nodes ?? [],
-  );
+  const [nodes, setNodes] = useState<TreeNodeItem[]>(existingTree?.nodes ?? []);
   const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
   const [isManageMode, setIsManageMode] = useState(false);
   const [nodeSheetMode, setNodeSheetMode] = useState<NodeSheetMode | null>(null);
   const [isPreviewOpen, setIsPreviewOpen] = useState(false);
-  const [previewAnswer, setPreviewAnswer] = useState<{ type: "TREE_TEST"; selectedNodeId: string | null }>({ type: "TREE_TEST", selectedNodeId: null });
+  const [previewAnswer, setPreviewAnswer] = useState<{
+    type: "TREE_TEST";
+    selectedNodeId: string | null;
+  }>({ type: "TREE_TEST", selectedNodeId: null });
 
   const isCompleteDisabled =
     questionTitle.trim().length === 0 ||
     nodes.length === 0 ||
     nodes.some((node) => node.children.length === 0);
 
-  const findNode = (
-    list: TreeNodeItem[],
-    nodeId: string,
-  ): TreeNodeItem | null => {
+  const findNode = (list: TreeNodeItem[], nodeId: string): TreeNodeItem | null => {
     for (const node of list) {
       if (node.id === nodeId) return node;
       const found = findNode(node.children, nodeId);
@@ -60,21 +53,14 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
     return null;
   };
 
-  const renameNode = (
-    list: TreeNodeItem[],
-    nodeId: string,
-    name: string,
-  ): TreeNodeItem[] =>
+  const renameNode = (list: TreeNodeItem[], nodeId: string, name: string): TreeNodeItem[] =>
     list.map((node) =>
       node.id === nodeId
         ? { ...node, name }
         : { ...node, children: renameNode(node.children, nodeId, name) },
     );
 
-  const deleteNode = (
-    list: TreeNodeItem[],
-    nodeId: string,
-  ): TreeNodeItem[] =>
+  const deleteNode = (list: TreeNodeItem[], nodeId: string): TreeNodeItem[] =>
     list
       .filter((node) => node.id !== nodeId)
       .map((node) => ({ ...node, children: deleteNode(node.children, nodeId) }));
@@ -119,10 +105,8 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
     setNodes((prev) => appendChild(prev, parentId, createNode(newName)));
   };
 
-  const sheetTitle =
-    nodeSheetMode?.kind === "rename" ? "기능 이름 수정" : "기능 추가하기";
-  const sheetInitialName =
-    nodeSheetMode?.kind === "rename" ? nodeSheetMode.initialName : "";
+  const sheetTitle = nodeSheetMode?.kind === "rename" ? "기능 이름 수정" : "기능 추가하기";
+  const sheetInitialName = nodeSheetMode?.kind === "rename" ? nodeSheetMode.initialName : "";
 
   return (
     <motion.div
@@ -200,14 +184,18 @@ export function TreeCreatePage({ questionId, onClose }: TreeCreatePageProps) {
             answer={previewAnswer}
             onChange={setPreviewAnswer}
           />
-          <FixedBottomCTA onClick={() => setIsPreviewOpen(false)}>
+          <FixedBottomCTA color="dark" variant="weak" onClick={() => setIsPreviewOpen(false)}>
             돌아가기
           </FixedBottomCTA>
         </motion.div>
       )}
 
       <TreeNodeAddSheet
-        key={nodeSheetMode ? `${nodeSheetMode.kind}-${'nodeId' in nodeSheetMode ? nodeSheetMode.nodeId : 'root'}` : 'closed'}
+        key={
+          nodeSheetMode
+            ? `${nodeSheetMode.kind}-${"nodeId" in nodeSheetMode ? nodeSheetMode.nodeId : "root"}`
+            : "closed"
+        }
         open={nodeSheetMode !== null}
         title={sheetTitle}
         initialName={sheetInitialName}

--- a/src/features/test-create/ui/GuideAccordionItem.tsx
+++ b/src/features/test-create/ui/GuideAccordionItem.tsx
@@ -4,11 +4,14 @@ import type { ReactNode } from "react";
 interface GuideAccordionItemProps {
   title: string;
   children: ReactNode;
+  isOpened: boolean;
+  onOpen: () => void;
+  onClose: () => void;
 }
 
-export function GuideAccordionItem({ title, children }: GuideAccordionItemProps) {
+export function GuideAccordionItem({ title, children, isOpened, onOpen, onClose }: GuideAccordionItemProps) {
   return (
-    <BoardRow title={title} icon={<BoardRow.ArrowIcon />}>
+    <BoardRow title={title} icon={<BoardRow.ArrowIcon />} isOpened={isOpened} onOpen={onOpen} onClose={onClose}>
       {children}
     </BoardRow>
   );

--- a/src/features/test-create/ui/QuestionManageSheet.tsx
+++ b/src/features/test-create/ui/QuestionManageSheet.tsx
@@ -1,9 +1,31 @@
 import { useState } from "react";
 import { motion } from "framer-motion";
-import { Top, FixedBottomCTA, CTAButton, ListRow, IconButton, Asset, Text, ConfirmDialog } from "@toss/tds-mobile";
+import {
+  Top,
+  FixedBottomCTA,
+  CTAButton,
+  ListRow,
+  IconButton,
+  Asset,
+  Text,
+  ConfirmDialog,
+} from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
-import { DndContext, MouseSensor, TouchSensor, useSensor, useSensors, closestCenter, type DragEndEvent } from "@dnd-kit/core";
-import { SortableContext, useSortable, arrayMove, verticalListSortingStrategy } from "@dnd-kit/sortable";
+import {
+  DndContext,
+  MouseSensor,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { QUESTION_TYPES, type PendingQuestion } from "../model/types";
 
@@ -21,7 +43,9 @@ interface SortableItemProps {
 }
 
 function SortableQuestionItem({ question, onDeleteRequest }: SortableItemProps) {
-  const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({ id: question.id });
+  const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({
+    id: question.id,
+  });
   const type = QUESTION_TYPES.find((t) => t.id === question.typeId);
   if (!type) return null;
 
@@ -39,7 +63,14 @@ function SortableQuestionItem({ question, onDeleteRequest }: SortableItemProps) 
       <ListRow
         left={
           <div className="flex items-center gap-2">
-            <Asset.Icon frameShape={{ width: 20, height: 20 }} backgroundColor="transparent" name="icon-navigation-menu-mono" color={adaptive.grey400} aria-hidden ratio="1/1" />
+            <Asset.Icon
+              frameShape={Asset.frameShape.CleanW20}
+              backgroundColor="transparent"
+              name="icon-dots-six-vertical-mono"
+              color={adaptive.grey400}
+              aria-hidden={true}
+              ratio="1/1"
+            />
             <ListRow.AssetIcon size="xsmall" shape="original" name={type.iconName} />
           </div>
         }
@@ -56,7 +87,7 @@ function SortableQuestionItem({ question, onDeleteRequest }: SortableItemProps) 
           <div onPointerDown={(e) => e.stopPropagation()}>
             <IconButton
               src="https://static.toss.im/icons/png/4x/icon-bin-mono.png"
-              iconSize={20}
+              iconSize={24}
               variant="clear"
               color={adaptive.grey400}
               aria-label="삭제"
@@ -70,7 +101,13 @@ function SortableQuestionItem({ question, onDeleteRequest }: SortableItemProps) 
   );
 }
 
-export function QuestionManageSheet({ questions, onDelete, onReorder, onSave, onCancel }: QuestionManageSheetProps) {
+export function QuestionManageSheet({
+  questions,
+  onDelete,
+  onReorder,
+  onSave,
+  onCancel,
+}: QuestionManageSheetProps) {
   const [pendingDeleteId, setPendingDeleteId] = useState<string | null>(null);
   const [isSaveDialogOpen, setIsSaveDialogOpen] = useState(false);
 
@@ -101,7 +138,13 @@ export function QuestionManageSheet({ questions, onDelete, onReorder, onSave, on
   };
 
   return (
-    <motion.div className="fixed inset-0 z-50 flex flex-col bg-white" initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }} transition={{ duration: 0.2 }}>
+    <motion.div
+      className="fixed inset-0 z-50 flex flex-col bg-white"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      exit={{ opacity: 0 }}
+      transition={{ duration: 0.2 }}
+    >
       <Top
         title={
           <Top.TitleParagraph size={22} color={adaptive.grey900}>
@@ -118,28 +161,30 @@ export function QuestionManageSheet({ questions, onDelete, onReorder, onSave, on
         </Text>
       </div>
 
-      <div className="flex-1 overflow-y-auto">
+      <div className="flex-1 overflow-y-auto pb-28">
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-          <SortableContext items={questions.map((q) => q.id)} strategy={verticalListSortingStrategy}>
+          <SortableContext
+            items={questions.map((q) => q.id)}
+            strategy={verticalListSortingStrategy}
+          >
             {questions.map((q) => (
               <SortableQuestionItem key={q.id} question={q} onDeleteRequest={setPendingDeleteId} />
             ))}
           </SortableContext>
         </DndContext>
+        <FixedBottomCTA.Double
+          leftButton={
+            <CTAButton className="w-full" color="dark" variant="weak" onClick={onCancel}>
+              취소
+            </CTAButton>
+          }
+          rightButton={
+            <CTAButton className="w-full" onClick={() => setIsSaveDialogOpen(true)}>
+              저장하기
+            </CTAButton>
+          }
+        />
       </div>
-
-      <FixedBottomCTA.Double
-        leftButton={
-          <CTAButton className="w-full" color="dark" variant="weak" onClick={onCancel}>
-            취소
-          </CTAButton>
-        }
-        rightButton={
-          <CTAButton className="w-full" onClick={() => setIsSaveDialogOpen(true)}>
-            저장하기
-          </CTAButton>
-        }
-      />
 
       <ConfirmDialog
         open={pendingDeleteId !== null}

--- a/src/features/test-create/ui/QuestionManageSheet.tsx
+++ b/src/features/test-create/ui/QuestionManageSheet.tsx
@@ -5,9 +5,9 @@ import {
   FixedBottomCTA,
   CTAButton,
   ListRow,
+  ListHeader,
   IconButton,
   Asset,
-  Text,
   ConfirmDialog,
 } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
@@ -146,6 +146,7 @@ export function QuestionManageSheet({
       transition={{ duration: 0.2 }}
     >
       <Top
+        lowerGap={0}
         title={
           <Top.TitleParagraph size={22} color={adaptive.grey900}>
             질문을 삭제하거나
@@ -155,11 +156,16 @@ export function QuestionManageSheet({
         }
       />
 
-      <div className="px-6 pt-6 pb-2">
-        <Text color={adaptive.grey700} typography="t7" fontWeight="regular">
-          질문 목록
-        </Text>
-      </div>
+      <ListHeader
+        descriptionPosition="bottom"
+        rightAlignment="center"
+        titleWidthRatio={0.6}
+        title={
+          <ListHeader.TitleParagraph typography="t5" fontWeight="medium" color={adaptive.grey600}>
+            질문 목록
+          </ListHeader.TitleParagraph>
+        }
+      />
 
       <div className="flex-1 overflow-y-auto pb-28">
         <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>

--- a/src/features/test-create/ui/TestCreateFunnel.tsx
+++ b/src/features/test-create/ui/TestCreateFunnel.tsx
@@ -20,6 +20,7 @@ import { useTestCreateForm } from "../model/useTestCreateForm";
 import { useSubmitTest } from "../model/useSubmitTest";
 import type { BasicSubStep, EditPhase, QuestionTypeId } from "../model/types";
 import { ROUTES } from "@/shared/constants/routes";
+import { useScrollLock } from "@/shared/hooks/useScrollLock";
 import { MultipleCreatePage } from "@/features/question-multiple/create";
 import { ScaleCreatePage } from "@/features/question-scale/create";
 import { AbCreatePage } from "@/features/question-ab/create";
@@ -55,6 +56,10 @@ export function TestCreateFunnel({ draftId, fromPayment = false }: Props) {
   const [isExitDialogOpen, setIsExitDialogOpen] = useState(false);
   const { mutate: submitTest, isPending: isSubmitting } = useSubmitTest(draftId);
   const [showGuide, setShowGuide] = useState(false);
+
+  const isOverlayOpen =
+    isCategorySheetOpen || editPhase !== null || activeQuestion !== null || showGuide;
+  useScrollLock(isOverlayOpen);
   const blurTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const exitUnsubscribeRef = useRef<(() => void) | null>(null);
 

--- a/src/features/test-create/ui/TestGuidePage.tsx
+++ b/src/features/test-create/ui/TestGuidePage.tsx
@@ -1,6 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import { motion } from "framer-motion";
-import { Top, Post, BottomCTA } from "@toss/tds-mobile";
+import { Top, Post, FixedBottomCTA } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { GuideAccordionItem } from "./GuideAccordionItem";
 
@@ -9,72 +9,81 @@ interface TestGuidePageProps {
 }
 
 export function TestGuidePage({ onClose }: TestGuidePageProps) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+
+  const accordionProps = (index: number) => ({
+    isOpened: openIndex === index,
+    onOpen: () => setOpenIndex(index),
+    onClose: () => setOpenIndex(null),
+  });
+
   return (
     <motion.div
-      className="fixed inset-0 z-50 flex flex-col bg-white"
+      className="fixed inset-0 z-50 overflow-y-auto bg-white pb-28"
       initial={{ opacity: 0 }}
       animate={{ opacity: 1 }}
       exit={{ opacity: 0 }}
       transition={{ duration: 0.2 }}
+      style={
+        {
+          "--adaptiveHairlineBorder": "transparent",
+          "--tHairlineBackground": "transparent",
+        } as React.CSSProperties
+      }
     >
-      <Top
-        title={
-          <Top.TitleParagraph size={22} color={adaptive.grey900}>
-            테스트는{"\n"}이렇게 진행돼요
-          </Top.TitleParagraph>
-        }
-        subtitleBottom={
-          <Top.SubtitleParagraph size={15}>
-            총 8가지의 테스트 방식이 있어요
-          </Top.SubtitleParagraph>
-        }
-        right={
-          <Top.RightAssetContent
-            content={
-              <img
-                src="https://static.toss.im/ml-product/tosst-inapp_huc9tza798q5gg3g1ln3snfr.png"
-                aria-hidden={true}
-                style={{ width: 60, height: 60, objectFit: "contain" }}
-              />
-            }
-          />
-        }
-      />
-      <div
-        className="flex-1 overflow-y-auto pb-24"
-        style={{ "--adaptiveHairlineBorder": "transparent", "--tHairlineBackground": "transparent" } as React.CSSProperties}
-      >
-        <GuideAccordionItem title="1. 객관식">
+        <Top
+          title={
+            <Top.TitleParagraph size={22} color={adaptive.grey900}>
+              테스트는{"\n"}이렇게 진행돼요
+            </Top.TitleParagraph>
+          }
+          subtitleBottom={
+            <Top.SubtitleParagraph size={15}>총 8가지의 테스트 방식이 있어요</Top.SubtitleParagraph>
+          }
+          right={
+            <Top.RightAssetContent
+              content={
+                <img
+                  src="https://static.toss.im/ml-product/tosst-inapp_huc9tza798q5gg3g1ln3snfr.png"
+                  aria-hidden={true}
+                  style={{ width: 60, height: 60, objectFit: "contain" }}
+                />
+              }
+            />
+          }
+        />
+        <GuideAccordionItem title="1. 객관식" {...accordionProps(0)}>
           <Post.H4 paddingBottom={16}>객관식 테스트 방식</Post.H4>
           <Post.Paragraph paddingBottom={8} typography="t6">
             보기 중 하나를 고르는 질문이에요.
           </Post.Paragraph>
         </GuideAccordionItem>
 
-        <GuideAccordionItem title="2. 주관식">
+        <GuideAccordionItem title="2. 주관식" {...accordionProps(1)}>
           <Post.H4 paddingBottom={16}>주관식 테스트 방식</Post.H4>
           <Post.Paragraph paddingBottom={8} typography="t6">
             자유 텍스트 입력 생각을 글로 적어 답하는 질문이에요.
           </Post.Paragraph>
         </GuideAccordionItem>
 
-        <GuideAccordionItem title="3. 척도 질문">
+        <GuideAccordionItem title="3. 척도 질문" {...accordionProps(2)}>
           <Post.Paragraph paddingBottom={8} typography="t6">
             1~5점 척도로 평가하는 질문이에요.
           </Post.Paragraph>
         </GuideAccordionItem>
 
-        <GuideAccordionItem title="4. A/B 테스트">
+        <GuideAccordionItem title="4. A/B 테스트" {...accordionProps(3)}>
           <Post.H4 paddingBottom={16}>A/B 테스트 방식</Post.H4>
           <Post.Paragraph paddingBottom={8} typography="t6">
             두 디자인 중 하나를 고르는 테스트예요.
           </Post.Paragraph>
         </GuideAccordionItem>
 
-        <GuideAccordionItem title="5. 카드 소팅">
+        <GuideAccordionItem title="5. 카드 소팅" {...accordionProps(4)}>
           <Post.H4 paddingBottom={16}>카드 소팅이란?</Post.H4>
           <Post.Paragraph paddingBottom={16} typography="t6">
-            사용자가 정보를 어떻게 분류하고 그룹화하는지 파악하는 테스트예요. 카드에 적힌 항목들을 직접 묶어보게 하면서, 사용자의 멘탈 모델을 기반으로 정보 구조(IA)를 설계할 수 있어요.
+            사용자가 정보를 어떻게 분류하고 그룹화하는지 파악하는 테스트예요. 카드에 적힌 항목들을
+            직접 묶어보게 하면서, 사용자의 멘탈 모델을 기반으로 정보 구조(IA)를 설계할 수 있어요.
           </Post.Paragraph>
           <Post.H4 paddingBottom={16}>어떻게 진행되나요?</Post.H4>
           <Post.Ol paddingBottom={16}>
@@ -91,10 +100,11 @@ export function TestGuidePage({ onClose }: TestGuidePageProps) {
           </Post.Ul>
         </GuideAccordionItem>
 
-        <GuideAccordionItem title="6. 트리 테스트">
+        <GuideAccordionItem title="6. 트리 테스트" {...accordionProps(5)}>
           <Post.H4 paddingBottom={16}>트리 테스트란?</Post.H4>
           <Post.Paragraph paddingBottom={16} typography="t6">
-            웹사이트나 앱의 정보 구조(IA)가 사용자에게 직관적인지 검증하는 테스트예요. 실제 디자인 없이 메뉴 계층 구조만 텍스트로 보여주고, 사용자가 특정 항목을 찾아가는 과정을 관찰해요.
+            웹사이트나 앱의 정보 구조(IA)가 사용자에게 직관적인지 검증하는 테스트예요. 실제 디자인
+            없이 메뉴 계층 구조만 텍스트로 보여주고, 사용자가 특정 항목을 찾아가는 과정을 관찰해요.
           </Post.Paragraph>
           <Post.H4 paddingBottom={16}>어떻게 진행되나요?</Post.H4>
           <Post.Ol paddingBottom={16}>
@@ -111,21 +121,22 @@ export function TestGuidePage({ onClose }: TestGuidePageProps) {
           </Post.Ul>
         </GuideAccordionItem>
 
-        <GuideAccordionItem title="7. 5초 테스트">
+        <GuideAccordionItem title="7. 5초 테스트" {...accordionProps(6)}>
           <Post.H4 paddingBottom={16}>5초 테스트 방식</Post.H4>
           <Post.Paragraph paddingBottom={8} typography="t6">
             5초 후 기억나는 것을 답하는 테스트예요.
           </Post.Paragraph>
         </GuideAccordionItem>
 
-        <GuideAccordionItem title="8. 히트맵/도트맵">
+        <GuideAccordionItem title="8. 히트맵/도트맵" {...accordionProps(7)}>
           <Post.H4 paddingBottom={16}>히트맵/도트맵이란?</Post.H4>
           <Post.Paragraph paddingBottom={8} typography="t6">
             화면에서 눈길 가는 곳을 표시하는 테스트예요.
           </Post.Paragraph>
         </GuideAccordionItem>
-      </div>
-      <BottomCTA.Single fixed color="dark" variant="weak" onClick={onClose}>이전으로</BottomCTA.Single>
+      <FixedBottomCTA color="dark" variant="weak" onClick={onClose}>
+        이전으로
+      </FixedBottomCTA>
     </motion.div>
   );
 }

--- a/src/features/test-create/ui/TestImageStep.tsx
+++ b/src/features/test-create/ui/TestImageStep.tsx
@@ -320,6 +320,14 @@ export function TestImageStep({ onHasImagesChange, title = "테스트를 나타�
             </div>
           </SortableContext>
 
+          {imageUris.length >= 2 && (
+            <div className="px-5 pt-2">
+              <Text color="#4365cc" typography="t6" fontWeight="regular">
+                사진을 꾹 눌러 순서를 바꿀 수 있어요
+              </Text>
+            </div>
+          )}
+
           <DragOverlay modifiers={[restrictToHorizontalAxis]} dropAnimation={null}>
             {activeUri !== null ? (
               <div

--- a/src/features/test-create/ui/TestImageStep.tsx
+++ b/src/features/test-create/ui/TestImageStep.tsx
@@ -1,9 +1,29 @@
 import { useState, useEffect, useRef } from "react";
 import { Top, Asset, Text, Badge, BottomSheet, ListRow, Checkbox } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
-import { openCamera, fetchAlbumPhotos, OpenCameraPermissionError, FetchAlbumPhotosPermissionError } from "@apps-in-toss/web-framework";
-import { DndContext, DragOverlay, TouchSensor, useSensor, useSensors, closestCenter, type DragStartEvent, type DragEndEvent, type Modifier } from "@dnd-kit/core";
-import { SortableContext, useSortable, arrayMove, horizontalListSortingStrategy } from "@dnd-kit/sortable";
+import {
+  openCamera,
+  fetchAlbumPhotos,
+  OpenCameraPermissionError,
+  FetchAlbumPhotosPermissionError,
+} from "@apps-in-toss/web-framework";
+import {
+  DndContext,
+  DragOverlay,
+  TouchSensor,
+  useSensor,
+  useSensors,
+  closestCenter,
+  type DragStartEvent,
+  type DragEndEvent,
+  type Modifier,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  arrayMove,
+  horizontalListSortingStrategy,
+} from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { PhotoSelectSheet } from "./PhotoSelectSheet";
 import { useTestCreateForm } from "../model/useTestCreateForm";
@@ -14,8 +34,7 @@ const PREVIEW_SURFACE = "var(--token-tds-color-white, var(--adaptiveBackground, 
 
 const restrictToHorizontalAxis: Modifier = ({ transform }) => ({ ...transform, y: 0 });
 
-const getImageSortableIds = (uris: string[]) =>
-  uris.map((_, index) => `image-${index}`);
+const getImageSortableIds = (uris: string[]) => uris.map((_, index) => `image-${index}`);
 
 interface TestImageStepProps {
   onHasImagesChange?: (hasImages: boolean) => void;
@@ -31,7 +50,9 @@ interface SortableImageItemProps {
 }
 
 function SortableImageItem({ id, uri, index, onPreview, onRemove }: SortableImageItemProps) {
-  const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({ id });
+  const { setNodeRef, attributes, listeners, transform, transition, isDragging } = useSortable({
+    id,
+  });
 
   return (
     <div
@@ -119,7 +140,10 @@ function SortableImageItem({ id, uri, index, onPreview, onRemove }: SortableImag
   );
 }
 
-export function TestImageStep({ onHasImagesChange, title = "테스트를 나타낼 수 있는 이미지를 첨부해주세요" }: TestImageStepProps) {
+export function TestImageStep({
+  onHasImagesChange,
+  title = "테스트를 나타낼 수 있는 이미지를 첨부해주세요",
+}: TestImageStepProps) {
   const form = useTestCreateForm();
   const imageUris = form.images;
   const imageListRef = useRef<HTMLDivElement | null>(null);
@@ -130,7 +154,7 @@ export function TestImageStep({ onHasImagesChange, title = "테스트를 나타�
   const sensors = useSensors(
     useSensor(TouchSensor, {
       activationConstraint: { delay: 500, tolerance: 8 },
-    })
+    }),
   );
 
   useEffect(() => {
@@ -201,7 +225,11 @@ export function TestImageStep({ onHasImagesChange, title = "테스트를 나타�
     try {
       const remaining = MAX_IMAGES - imageUris.length;
       if (remaining <= 0) return;
-      const response = await fetchAlbumPhotos({ base64: true, maxWidth: 1280, maxCount: remaining });
+      const response = await fetchAlbumPhotos({
+        base64: true,
+        maxWidth: 1280,
+        maxCount: remaining,
+      });
       addImages(response.map((img) => `data:image/jpeg;base64,${img.dataUri}`));
     } catch (error) {
       if (error instanceof FetchAlbumPhotosPermissionError) {
@@ -253,7 +281,7 @@ export function TestImageStep({ onHasImagesChange, title = "테스트를 나타�
             </Top.TitleParagraph>
           }
           subtitleBottom={
-            <Top.SubtitleParagraph size={15} color={adaptive.blue500}>
+            <Top.SubtitleParagraph size={15} color={adaptive.grey600}>
               16:9 비율이 최적이에요.
             </Top.SubtitleParagraph>
           }
@@ -269,14 +297,18 @@ export function TestImageStep({ onHasImagesChange, title = "테스트를 나타�
           onDragCancel={handleDragCancel}
         >
           <SortableContext items={ids} strategy={horizontalListSortingStrategy}>
-            <div ref={imageListRef} className="px-5 flex flex-nowrap gap-2 overflow-x-auto scrollbar-hide">
+            <div
+              ref={imageListRef}
+              className="px-5 flex flex-nowrap gap-2 overflow-x-auto scrollbar-hide"
+            >
               {imageUris.length < MAX_IMAGES && (
                 <button
                   type="button"
                   style={{
                     width: 88,
                     height: 88,
-                    backgroundColor: "var(--token-tds-color-grey-100, var(--adaptiveGrey100, #f2f4f6))",
+                    backgroundColor:
+                      "var(--token-tds-color-grey-100, var(--adaptiveGrey100, #f2f4f6))",
                     borderRadius: 16,
                     padding: 16,
                     display: "flex",
@@ -362,12 +394,19 @@ export function TestImageStep({ onHasImagesChange, title = "테스트를 나타�
       <BottomSheet
         header={<BottomSheet.Header>이미지 미리보기</BottomSheet.Header>}
         headerDescription={
-          <BottomSheet.HeaderDescription>테스트 상세 화면에 이렇게 보여요</BottomSheet.HeaderDescription>
+          <BottomSheet.HeaderDescription>
+            테스트 상세 화면에 이렇게 보여요
+          </BottomSheet.HeaderDescription>
         }
         open={previewIndex !== null}
         onClose={() => setPreviewIndex(null)}
         cta={
-          <BottomSheet.CTA color="dark" variant="weak" disabled={false} onClick={() => setPreviewIndex(null)}>
+          <BottomSheet.CTA
+            color="dark"
+            variant="weak"
+            disabled={false}
+            onClick={() => setPreviewIndex(null)}
+          >
             닫기
           </BottomSheet.CTA>
         }
@@ -398,7 +437,13 @@ export function TestImageStep({ onHasImagesChange, title = "테스트를 나타�
                   <img
                     src={previewUri}
                     alt=""
-                    style={{ position: "absolute", inset: 0, width: "100%", height: "100%", objectFit: "cover" }}
+                    style={{
+                      position: "absolute",
+                      inset: 0,
+                      width: "100%",
+                      height: "100%",
+                      objectFit: "cover",
+                    }}
                   />
                 </div>
               </div>

--- a/src/features/test-create/ui/TestRegisterStep.tsx
+++ b/src/features/test-create/ui/TestRegisterStep.tsx
@@ -92,7 +92,7 @@ export function TestRegisterStep({ activeTab, onTabChange, onEnterQuestion, onGu
             />
             <div
               style={{
-                backgroundColor: "var(--adaptiveCardBgGrey)",
+                backgroundColor: "#00173305",
                 borderRadius: 16,
                 margin: "0 20px",
                 overflow: "hidden",

--- a/src/features/test-participate/model/validation.ts
+++ b/src/features/test-participate/model/validation.ts
@@ -21,10 +21,14 @@ export function isAnswerValid(
     }
     case "OBJECTIVE": {
       const a = answer as Extract<Answer, { type: "OBJECTIVE" }>;
-      const hasOtherChoice = question.data.choices.some((c) => c.name === "기타 (직접 입력)");
-      if (hasOtherChoice && (a.otherText ?? "").trim().length > 0) {
-        return true;
+      const otherChoice = question.data.choices.find((c) => c.name === "기타 (직접 입력)");
+      const isOtherSelected = !!otherChoice && a.selectedIds.includes(otherChoice.id);
+
+      // "기타"가 선택됐는데 텍스트가 비어있으면 무효
+      if (isOtherSelected && (a.otherText ?? "").trim().length === 0) {
+        return false;
       }
+
       const n = a.selectedIds.length;
 
       if (!question.data.isMultiSelectEnabled) {
@@ -49,10 +53,14 @@ export function isAnswerValid(
       if (question.data.answerType === "subjective") {
         return (a.text ?? "").trim().length > 0;
       }
-      const hasOtherChoice = question.data.choices.some((c) => c.name === "기타 (직접 입력)");
-      if (hasOtherChoice && (a.text ?? "").trim().length > 0) {
-        return true;
+      const otherChoice = question.data.choices.find((c) => c.name === "기타 (직접 입력)");
+      const isOtherSelected = !!otherChoice && a.selectedIds.includes(otherChoice.id);
+
+      // "기타"가 선택됐는데 텍스트가 비어있으면 무효
+      if (isOtherSelected && (a.text ?? "").trim().length === 0) {
+        return false;
       }
+
       const n = a.selectedIds.length;
 
       if (!question.data.isMultiSelectEnabled) {

--- a/src/features/test-participate/ui/ParticipatePage.tsx
+++ b/src/features/test-participate/ui/ParticipatePage.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import { useQueryClient } from "@tanstack/react-query";
-import { Asset, CTAButton, FixedBottomCTA, ProgressBar, Spacing, Text } from "@toss/tds-mobile";
+import { Asset, CTAButton, ConfirmDialog, FixedBottomCTA, ProgressBar, Spacing, Text } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
+import { graniteEvent } from "@apps-in-toss/web-framework";
 import { useParticipateFunnel } from "../model";
 import { ROUTES } from "@/shared/constants/routes";
 import { QuestionRenderer } from "./QuestionRenderer";
@@ -60,6 +61,30 @@ function ParticipateFunnelContent({ test, testId }: FunnelProps) {
   const queryClient = useQueryClient();
   const { mutate: submitAnswers } = useSubmitAnswersMutation();
   const [submitted, setSubmitted] = useState(false);
+  const [isExitDialogOpen, setIsExitDialogOpen] = useState(false);
+  const exitUnsubscribeRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    if (submitted) return;
+    try {
+      const unsubscribe = graniteEvent.addEventListener("backEvent", {
+        onEvent: () => {
+          setIsExitDialogOpen(true);
+        },
+        onError: (error) => {
+          console.error("backEvent error", error);
+        },
+      });
+      exitUnsubscribeRef.current = unsubscribe;
+      return () => {
+        unsubscribe();
+        exitUnsubscribeRef.current = null;
+      };
+    } catch {
+      console.warn("backEvent listener not supported in browser");
+      return () => {};
+    }
+  }, [submitted]);
 
   const funnel = useParticipateFunnel(test.questions, (answers) => {
     const body = mapAnswersToApiRequest(test.questions, answers);
@@ -153,6 +178,24 @@ function ParticipateFunnelContent({ test, testId }: FunnelProps) {
           }
         />
       )}
+
+      <ConfirmDialog
+        open={isExitDialogOpen}
+        title="테스트를 그만둘까요?"
+        description="지금 나가면 리워드를 못 받아요"
+        cancelButton={
+          <ConfirmDialog.CancelButton size="xlarge" onClick={() => setIsExitDialogOpen(false)}>
+            닫기
+          </ConfirmDialog.CancelButton>
+        }
+        confirmButton={
+          <ConfirmDialog.ConfirmButton color="danger" size="xlarge" onClick={() => navigate({ to: ROUTES.DISCOVERY })}>
+            나가기
+          </ConfirmDialog.ConfirmButton>
+        }
+        onClose={() => setIsExitDialogOpen(false)}
+        closeOnBackEvent={false}
+      />
     </div>
   );
 }

--- a/src/features/test-participate/ui/ParticipatePage.tsx
+++ b/src/features/test-participate/ui/ParticipatePage.tsx
@@ -15,9 +15,10 @@ import type { ParticipateTest } from "../model/types";
 
 interface Props {
   testId: number;
+  reward?: number;
 }
 
-export function ParticipatePage({ testId }: Props) {
+export function ParticipatePage({ testId, reward }: Props) {
   const { data, isLoading, isError, error } = useParticipateTestQuery(testId);
 
   if (isLoading) {
@@ -48,18 +49,19 @@ export function ParticipatePage({ testId }: Props) {
     );
   }
 
-  return <ParticipateFunnelContent test={data.test} testId={testId} />;
+  return <ParticipateFunnelContent test={data.test} testId={testId} reward={reward} />;
 }
 
 interface FunnelProps {
   test: ParticipateTest;
   testId: number;
+  reward?: number;
 }
 
-function ParticipateFunnelContent({ test, testId }: FunnelProps) {
+function ParticipateFunnelContent({ test, testId, reward }: FunnelProps) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { mutate: submitAnswers } = useSubmitAnswersMutation();
+  const { mutate: submitAnswers, isPending: isSubmitting } = useSubmitAnswersMutation();
   const [submitted, setSubmitted] = useState(false);
   const [isExitDialogOpen, setIsExitDialogOpen] = useState(false);
   const exitUnsubscribeRef = useRef<(() => void) | null>(null);
@@ -126,7 +128,7 @@ function ParticipateFunnelContent({ test, testId }: FunnelProps) {
           fontWeight="regular"
           textAlign="center"
         >
-          적립 예정 보상 500원{"\n"}보상은 24시간 이내 지급돼요.
+          {reward != null ? `적립 예정 보상 ${reward.toLocaleString()}원` : "적립 예정 보상이 지급돼요."}{"\n"}보상은 24시간 이내 지급돼요.
         </Text>
         <FixedBottomCTA onClick={() => navigate({ to: ROUTES.DISCOVERY })}>
           확인
@@ -161,19 +163,19 @@ function ParticipateFunnelContent({ test, testId }: FunnelProps) {
           {"다음"}
         </FixedBottomCTA>
       ) : isFirst && isLast ? (
-        <FixedBottomCTA disabled={!canGoNext} onClick={goNext}>
-          {"완료하기"}
+        <FixedBottomCTA disabled={!canGoNext || isSubmitting} onClick={goNext}>
+          {isSubmitting ? "제출 중" : "완료하기"}
         </FixedBottomCTA>
       ) : (
         <FixedBottomCTA.Double
           leftButton={
-            <CTAButton color="dark" variant="weak" onClick={goPrev}>
+            <CTAButton color="dark" variant="weak" onClick={goPrev} disabled={isSubmitting}>
               이전
             </CTAButton>
           }
           rightButton={
-            <CTAButton disabled={!canGoNext} onClick={goNext}>
-              {isLast ? "완료하기" : "다음"}
+            <CTAButton disabled={!canGoNext || isSubmitting} onClick={goNext}>
+              {isLast ? (isSubmitting ? "제출 중" : "완료하기") : "다음"}
             </CTAButton>
           }
         />

--- a/src/routes/discovery/$testId.tsx
+++ b/src/routes/discovery/$testId.tsx
@@ -50,7 +50,7 @@ function TestDetailPage() {
         <BottomCTA.Single
           disabled={isWaiting}
           onClick={() =>
-            navigate({ to: ROUTES.TEST_PARTICIPATE, params: { testId } })
+            navigate({ to: ROUTES.TEST_PARTICIPATE, params: { testId }, search: { reward: detail.reward } })
           }
         >
           {isWaiting ? "검토중인 테스트예요" : "테스트 참여하기"}

--- a/src/routes/interest/$testId.tsx
+++ b/src/routes/interest/$testId.tsx
@@ -77,7 +77,7 @@ function InterestTestDetailPage() {
         ) : (
           <BottomCTA.Single
             onClick={() =>
-              navigate({ to: ROUTES.TEST_PARTICIPATE, params: { testId } })
+              navigate({ to: ROUTES.TEST_PARTICIPATE, params: { testId }, search: { reward: detail.reward } })
             }
           >
             테스트 참여하기

--- a/src/routes/test/participate.$testId.tsx
+++ b/src/routes/test/participate.$testId.tsx
@@ -2,8 +2,12 @@ import { createFileRoute } from "@tanstack/react-router";
 import { ParticipatePage } from "@/features/test-participate/ui";
 
 export const Route = createFileRoute("/test/participate/$testId")({
+  validateSearch: (search: Record<string, unknown>) => ({
+    reward: search.reward != null ? Number(search.reward) : undefined,
+  }),
   component: function ParticipateRoute() {
     const { testId } = Route.useParams();
-    return <ParticipatePage testId={Number(testId)} />;
+    const { reward } = Route.useSearch();
+    return <ParticipatePage testId={Number(testId)} reward={reward} />;
   },
 });

--- a/src/shared/hooks/useScrollLock.ts
+++ b/src/shared/hooks/useScrollLock.ts
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+
+export function useScrollLock(locked: boolean) {
+  useEffect(() => {
+    if (!locked) return;
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prev;
+    };
+  }, [locked]);
+}


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [x] 버그 수정
-   [x] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #113

## 👩🏻‍💻 작업 사항

- 오버레이(질문 생성, 가이드 등) 열릴 때 배경 스크롤 잠금 (`useScrollLock` 훅 추가)
- `TestGuidePage`, `QuestionManageSheet` 하단 버튼 그라디언트 레이아웃 수정 (FixedBottomCTA를 overflow-y-auto 컨테이너 안으로 이동)
- `GuideAccordionItem` 아코디언 열림/닫힘 상태 연결
- `QuestionManageSheet` 질문 목록 헤더 `ListHeader` 컴포넌트로 교체
- 5초 테스트 미리보기 `preview` · `countdown` 단계에 돌아가기 버튼 추가
- 테스트 이미지 등록 UI 수정 및 이미지 2개 이상 드래그 순서 변경 안내 문구 추가
- 테스트 참여 뒤로가기 모달 및 기타 선택 유효성 개선
- 테스트 질문 추가 버튼 배경색 추가

## 📢 기타(공유 사항)

- `useScrollLock`은 `src/shared/hooks/`에 추가되어 다른 곳에서도 재사용 가능