### PR TITLE
[FIX] API 오류 처리 개선 및 캐싱 정책 수정

### DIFF
--- a/src/features/discovery/ui/TestList.tsx
+++ b/src/features/discovery/ui/TestList.tsx
@@ -7,6 +7,7 @@ import { TestCard } from "./TestCard";
 interface Props {
   tests: DiscoveryTest[];
   isLoading?: boolean;
+  isError?: boolean;
   onRetry?: () => void;
 }
 
@@ -25,11 +26,34 @@ function TestListSkeleton() {
   );
 }
 
-export function TestList({ tests, isLoading = false, onRetry }: Props) {
+export function TestList({ tests, isLoading = false, isError = false, onRetry }: Props) {
   const navigate = useNavigate();
 
   if (isLoading) {
     return <TestListSkeleton />;
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-col min-h-screen items-center justify-center px-6">
+        <Result
+          title="테스트 목록을 불러오지 못했어요"
+          description="잠시 후 다시 시도해 주세요"
+          figure={
+            <Asset.Lottie
+              frameShape={Asset.frameShape.CleanW60}
+              src="https://static.toss.im/lotties-common/error-spot.json"
+              aria-hidden={true}
+            />
+          }
+          button={
+            <Result.Button color="dark" variant="weak" onClick={onRetry}>
+              다시 시도하기
+            </Result.Button>
+          }
+        />
+      </div>
+    );
   }
 
   return (

--- a/src/features/test-result/ui/TestResultPage.tsx
+++ b/src/features/test-result/ui/TestResultPage.tsx
@@ -9,6 +9,7 @@ import {
   Tab,
   Text,
   Top,
+  useToast,
 } from "@toss/tds-mobile";
 import { adaptive } from "@toss/tds-colors";
 import { ResultTabContent } from "./ResultTabContent";
@@ -63,6 +64,7 @@ export function TestResultPage({ testId }: Props) {
   });
   const testTitle = (testDetailData?.data?.data as { title?: string } | undefined)?.title ?? testId;
 
+  const { openToast } = useToast();
   const { generate: generatePdf, isGenerating: isPdfGenerating } = usePdfDownload(testId, testTitle);
   const { generate: generateCsv, isGenerating: isCsvGenerating } = useCsvDownload(testId, testTitle);
   const isGenerating = isPdfGenerating || isCsvGenerating;
@@ -94,7 +96,7 @@ export function TestResultPage({ testId }: Props) {
     };
   }, []);
 
-  const { data: reportData, isLoading } = useGetReportQuery(Number(testId));
+  const { data: reportData, isLoading, isError, refetch } = useGetReportQuery(Number(testId));
   const report = reportData?.data;
 
   const { data: questionSummary = [] } = useGetQuestionSummaryQuery(Number(testId));
@@ -110,12 +112,35 @@ export function TestResultPage({ testId }: Props) {
     return <TestResultSkeleton />;
   }
 
+  if (isError) {
+    return (
+      <div className="flex flex-col min-h-screen items-center justify-center px-6">
+        <Result
+          title="통계를 불러오지 못했어요"
+          description="잠시 후 다시 시도해 주세요"
+          figure={
+            <Asset.Lottie
+              frameShape={Asset.frameShape.CleanW60}
+              src="https://static.toss.im/lotties-common/error-spot.json"
+              aria-hidden={true}
+            />
+          }
+          button={
+            <Result.Button color="dark" variant="weak" onClick={() => refetch()}>
+              다시 시도하기
+            </Result.Button>
+          }
+        />
+      </div>
+    );
+  }
+
   async function handleDownload(format: "pdf" | "csv") {
     try {
       if (format === "pdf") await generatePdf();
       if (format === "csv") await generateCsv();
     } catch {
-      alert("다운로드에 실패했습니다. 다시 시도해주세요.");
+      openToast("다운로드에 실패했습니다. 다시 시도해주세요.", { type: "bottom" });
     }
     setIsDownloadSheetOpen(false);
   }

--- a/src/routes/discovery/index.tsx
+++ b/src/routes/discovery/index.tsx
@@ -10,7 +10,7 @@ export const Route = createFileRoute("/discovery/")({
 });
 
 function HomePage() {
-  const { data, isLoading, refetch } = useQuery({
+  const { data, isLoading, isError, refetch } = useQuery({
     queryKey: [getListTestsUrl()],
     queryFn: listTests,
   });
@@ -29,7 +29,7 @@ function HomePage() {
   return (
     <div className="flex flex-col pb-19">
       <ServiceBanner />
-      <TestList tests={tests} isLoading={isLoading} onRetry={refetch} />
+      <TestList tests={tests} isLoading={isLoading} isError={isError} onRetry={refetch} />
       <BottomTabBar activeTab="discover" />
     </div>
   );

--- a/src/shared/api/question.ts
+++ b/src/shared/api/question.ts
@@ -241,8 +241,6 @@ export function useGetQuestionSummaryQuery(testId: number) {
       })) as QuestionSummaryListItem[];
     },
     enabled: !!testId,
-    staleTime: Infinity,
-    gcTime: 1000 * 60 * 30,
   });
 }
 


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [x] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [x] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [ ] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #

## 👩🏻‍💻 작업 사항

### API 오류 처리 개선
- 탐색 페이지(`discovery`) API 실패 시 Result 컴포넌트 기반 에러 UI 및 다시 시도 버튼 추가
- 통계 보고서 페이지(`test-result`) API 실패 시 동일한 에러 UI 패턴 적용
- 다운로드 실패 시 `alert()` 대신 `useToast`로 피드백 변경

### 캐싱 정책 수정
- `useGetQuestionSummaryQuery`의 `staleTime: Infinity` 제거
- 질문 목록은 변경 가능성이 있어 전역 기본값(1분)을 따르도록 수정

## 📢 기타(공유 사항)
- 에러 UI는 기존 `InterestList` 패턴(`Result` + `Asset.Lottie` + 다시 시도하기)과 동일하게 맞춤