### PR TITLE
[CHORE] 실기기 테스트 위해 proxy 설정

### DIFF
--- a/src/shared/api/client.ts
+++ b/src/shared/api/client.ts
@@ -12,11 +12,15 @@ export const clearRefreshToken = () => { _refreshToken = null; };
 
 const REISSUE_PATH = "api/v1/auth/reissue";
 
+const API_BASE_URL = import.meta.env.DEV
+  ? `${window.location.origin}/`
+  : import.meta.env.VITE_API_BASE_URL;
+
 async function refreshAccessToken(): Promise<string> {
   if (_refreshPromise) return _refreshPromise;
 
   _refreshPromise = (async () => {
-    const baseUrl = import.meta.env.VITE_API_BASE_URL.replace(/\/$/, "");
+    const baseUrl = API_BASE_URL.replace(/\/$/, "");
     const res = await ky
       .post(`${baseUrl}/${REISSUE_PATH}`, {
         json: { refreshToken: _refreshToken },
@@ -38,7 +42,7 @@ async function refreshAccessToken(): Promise<string> {
 }
 
 export const client = ky.create({
-  prefixUrl: import.meta.env.VITE_API_BASE_URL,
+  prefixUrl: API_BASE_URL,
   credentials: "include",
   hooks: {
     beforeRequest: [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -19,5 +19,14 @@ export default defineConfig({
   server: {
     host: true,
     hmr: true,
+    proxy: {
+      "/api": {
+        target: process.env.VITE_API_BASE_URL,
+        changeOrigin: true,
+        headers: {
+          origin: "http://localhost:5173",
+        },
+      },
+    },
   },
 });


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [x] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #126

## 👩🏻‍💻 작업 사항

**문제**
`granite.config.ts`의 `host`를 localhost에서 실제 로컬 IP로 변경해 실기기에서 개발 서버에 접근하면 CORS 403 발생

**해결**
- `vite.config.ts`: `/api` 경로에 Vite dev proxy 추가. `Origin` 헤더를 `http://localhost:5173`으로 교체해 백엔드 CORS 통과
- `src/shared/api/client.ts`: dev 환경에서 `window.location.origin`을 base URL로 사용해 API 요청이 Vite proxy를 경유하도록 변경

**요청 흐름**
```
실기기 → http://{로컬IP}:5173/api/... (same-origin, preflight 없음)
           ↓ Vite proxy (Origin: localhost:5173 으로 교체)
         https://api.kusitms-mate.cloud/api/... (CORS 통과)
```

> 프록시는 dev server 전용 (`import.meta.env.DEV`)이며 프로덕션 빌드에 영향 없음

## 📢 기타(공유 사항)

실기기 테스트 시 `granite.config.ts`의 `host`를 본인 로컬 IP로 변경 후 사용 (커밋 금지)