### PR TITLE
[CHORE] Azure Blob Storage 이미지 업로드 프록시 설정

### DIFF
--- a/src/features/test-create/model/useSubmitTest.ts
+++ b/src/features/test-create/model/useSubmitTest.ts
@@ -100,7 +100,11 @@ async function uploadBase64(dataUri: string | undefined): Promise<string | undef
   const { presignedUrl, fileKey } = uploadResponse.data.data ?? {};
   if (!presignedUrl || !fileKey) throw new Error("업로드 URL 발급 실패");
 
-  await ky.put(presignedUrl, {
+  const uploadUrl = import.meta.env.DEV
+    ? (() => { const u = new URL(presignedUrl); return `/azure-blob${u.pathname}${u.search}`; })()
+    : presignedUrl;
+
+  await ky.put(uploadUrl, {
     body: blob,
     headers: { "x-ms-blob-type": "BlockBlob" },
   });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,11 @@ export default defineConfig({
           origin: "http://localhost:5173",
         },
       },
+      "/azure-blob": {
+        target: "https://matestoragedev.blob.core.windows.net",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/azure-blob/, ""),
+      },
     },
   },
 });


### PR DESCRIPTION
## 📍PR 유형 (하나 이상 선택)

-   [ ] 새로운 기능 추가
-   [ ] 버그 수정
-   [ ] CSS 등 사용자 UI 디자인 변경
-   [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
-   [ ] 코드 리팩토링
-   [ ] 주석 추가 및 수정
-   [ ] 문서 수정
-   [ ] 테스트 추가, 테스트 리팩토링
-   [x] 빌드 부분 혹은 패키지 매니저 수정
-   [ ] 파일 혹은 폴더명 수정
-   [ ] 파일 혹은 폴더 삭제

## ‼️ 관련 이슈

resolves #126

## 👩🏻‍💻 작업 사항

**문제**
실기기(`172.30.1.9`)에서 이미지 업로드 시 `matestoragedev.blob.core.windows.net`으로 브라우저가 직접 PUT 요청 → Azure Blob Storage CORS 미설정으로 preflight 403 발생

**해결**
- `vite.config.ts`: `/azure-blob` proxy 추가. Vite dev server 경유 시 `matestoragedev.blob.core.windows.net`으로 포워딩
- `useSubmitTest.ts`: dev 환경에서 SAS URL 도메인을 `/azure-blob` 경로로 교체

**요청 흐름**
```
dev: PUT http://172.30.1.9:5173/azure-blob/mate-public/...?sv=...&sig=...
       ↓ Vite proxy (/azure-blob 경로 제거)
     https://matestoragedev.blob.core.windows.net/mate-public/...?sv=...&sig=...

prod: PUT https://matestoragedev.blob.core.windows.net/... (직접)
```

> SAS 서명은 Azure 내부 키로 검증하므로 proxy 경유 후에도 유효

## 📢 기타(공유 사항)

#127 머지 이후 적용 필요 (dev proxy 기반 구조 의존)